### PR TITLE
Use coverage in travisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ before_install:
     - pip install black
     - pip install pydocstyle
     - pip install flask  # for unit tests
+    - pip install coverage
+    - pip install pytest-cov
 
 install:
     - pip install -r requirements.txt
@@ -44,4 +46,4 @@ script:
     - cd ..
 
     # Run unit tests
-    - PYTHONPATH=. pytest tests/test_*.py
+    - PYTHONPATH=. pytest  --cov-report term-missing:skip-covered --cov=coco tests/test_*.py

--- a/coco/master.py
+++ b/coco/master.py
@@ -113,8 +113,10 @@ class Master:
             logger.error(
                 f"Failed sending shutdown command to worker (have to kill it): {type(e)}: {e}"
             )
-            self.qworker.kill()
-        self.qworker.join()
+            if self.qworker:
+                self.qworker.kill()
+        if self.qworker:
+            self.qworker.join()
 
     def _call_endpoints_on_start(self):
         for endpoint in self.endpoints.values():

--- a/coco/master.py
+++ b/coco/master.py
@@ -11,8 +11,6 @@ import os
 import redis as redis_sync
 import time
 import yaml
-import asyncio
-import threading
 
 from multiprocessing import Process
 from sanic import Sanic

--- a/coco/master.py
+++ b/coco/master.py
@@ -83,7 +83,11 @@ class Master:
             target=worker.main_loop,
             args=(self.endpoints, self.forwarder, self.port, self.metrics_port, self.log_level),
         )
-        self.qworker.start()
+        self.qworker.daemon = True
+        try:
+            self.qworker.start()
+        except BaseException:
+            self.qworker.join()
 
         self._call_endpoints_on_start()
         self._start_server()

--- a/coco/test/coco_runner.py
+++ b/coco/test/coco_runner.py
@@ -64,13 +64,10 @@ class Runner:
         json.dump(CONFIG, configfile)
         configfile.flush()
 
-        return subprocess.Popen([COCO, "-c", configfile.name]), configfile, endpointdir
+        coco = subprocess.Popen([COCO, "-c", configfile.name])
+        return coco, configfile, endpointdir
 
     def stop_coco(self):
         """Stop coco script."""
-        try:
-            self.coco.communicate(timeout=0)
-        except subprocess.TimeoutExpired:
-            self.coco.kill()
-            self.coco.communicate()
-        self.coco.kill()
+        self.coco.terminate()
+        self.coco.communicate()

--- a/coco/test/coco_runner.py
+++ b/coco/test/coco_runner.py
@@ -47,7 +47,8 @@ class Runner:
         result = json.loads(result)
         return result
 
-    def start_coco(self, config, endpoint_configs):
+    @staticmethod
+    def start_coco(config, endpoint_configs):
         """Start coco with a given config."""
         CONFIG.update(config)
 

--- a/coco/test/endpoint_farm.py
+++ b/coco/test/endpoint_farm.py
@@ -26,7 +26,7 @@ def endpoint(name):
     try:
         return jsonify(callbacks[name](request.json))
     except KeyError:
-        return None
+        return jsonify({})
 
 
 def shutdown_server():

--- a/coco/test/endpoint_farm.py
+++ b/coco/test/endpoint_farm.py
@@ -19,7 +19,6 @@ callbacks = dict()
 @app.route("/<name>")
 def endpoint(name):
     """Accept any endpoint call."""
-    print(f"{name} called, received {request.json}")
     try:
         counters[int(request.host.split(":")[1])][name] += 1
     except KeyError:

--- a/coco/worker.py
+++ b/coco/worker.py
@@ -65,6 +65,11 @@ def main_loop(endpoints, forwarder, coco_port, metrics_port, log_level):
                 continue
             name = name[1]
 
+            # check for shutdown condition
+            if name == "coco_shutdown":
+                logger.info("coco.worker: Received shutdown command. Exiting...")
+                exit(0)
+
             # Use the name to get all info on the call and delete from redis.
             [method, endpoint_name, request] = await conn.execute(
                 "hmget", name, "method", "endpoint", "request"

--- a/tests/test_call_coco.py
+++ b/tests/test_call_coco.py
@@ -1,0 +1,66 @@
+"""Test call forwarding to other coco endpoints."""
+import pytest
+
+from coco.test import coco_runner
+from coco.test import endpoint_farm
+
+ENDPT_NAME = "proxy"
+ENDPT_NAME2 = "end"
+CONFIG = {"log_level": "INFO"}
+ENDPOINTS = {
+    ENDPT_NAME: {
+        "call": {"coco": ENDPT_NAME2},
+        "group": "test",
+        "values": {"foo": "int", "bar": "str"},
+    },
+    ENDPT_NAME2: {"group": "test", "values": {"foo": "int", "bar": "str"}},
+}
+N_CALLS = 2
+
+
+def callback(data):
+    """Reply with the incoming json request."""
+    return data
+
+
+N_HOSTS = 2
+CALLBACKS = {"end": callback}
+
+
+@pytest.fixture
+def farm():
+    """Create a coco runner."""
+    return endpoint_farm.Farm(N_HOSTS, CALLBACKS)
+
+
+@pytest.fixture
+def runner(farm):
+    """Create an endpoint test farm."""
+    CONFIG["groups"] = {"test": farm.hosts}
+    return coco_runner.Runner(CONFIG, ENDPOINTS)
+
+
+def test_forward(farm, runner):
+    """Test if a request gets forwarded to another coco endpoint."""
+    request = {"foo": 0, "bar": "1337"}
+    response = runner.client(ENDPT_NAME, request)
+
+    for p in farm.ports:
+        assert farm.counters()[p][ENDPT_NAME] == 1
+        assert farm.counters()[p][ENDPT_NAME2] == 1
+    assert ENDPT_NAME in response
+    assert ENDPT_NAME2 in response
+    response = response[ENDPT_NAME2]
+    for h in farm.hosts:
+        assert h in response[ENDPT_NAME2]
+        assert "status" in response[ENDPT_NAME2][h]
+        assert "reply" in response[ENDPT_NAME2][h]
+
+        assert response[ENDPT_NAME2][h]["status"] == 200
+        assert response[ENDPT_NAME2][h]["reply"] == request
+
+    for i in range(N_CALLS):
+        runner.client(ENDPT_NAME, request)
+    for p in farm.ports:
+        assert farm.counters()[p][ENDPT_NAME] == N_CALLS + 1
+        assert farm.counters()[p][ENDPT_NAME2] == N_CALLS + 1


### PR DESCRIPTION
This shows use the coverage of unit tests in percent (currently 54%) and the lines of code that are not tested. If we can manage to reach 100%, we can enforce it to stay like that (#92).

This also solves #89 by sending `coco_shutdown` through the queue from `Master.__del__`.