### PR TITLE
Slack logging

### DIFF
--- a/coco/__init__.py
+++ b/coco/__init__.py
@@ -5,7 +5,6 @@ from ._version import get_versions
 __version__ = get_versions()["version"]
 del get_versions
 
-from .slack import SlackExporter
 from .task_pool import TaskPool
 from .request_forwarder import RequestForwarder, ExternalForward, CocoForward
 from .result import Result

--- a/coco/endpoint.py
+++ b/coco/endpoint.py
@@ -202,7 +202,9 @@ class Endpoint:
 
             # Internal forwards
             forward_to_coco = forward_dict.get("coco", None)
-            self.logger.info(f"Endpoint /{self.name} settings: forwarding to coco: {forward_to_coco}")
+            self.logger.info(
+                f"Endpoint /{self.name} settings: forwarding to coco: {forward_to_coco}"
+            )
             if forward_to_coco:
                 if not isinstance(forward_to_coco, list):
                     forward_to_coco = [forward_to_coco]

--- a/coco/master.py
+++ b/coco/master.py
@@ -20,15 +20,7 @@ from sanic import Sanic, response
 
 from comet import Manager, CometError
 
-from . import (
-    Endpoint,
-    LocalEndpoint,
-    worker,
-    __version__,
-    RequestForwarder,
-    State,
-    wait,
-)
+from . import Endpoint, LocalEndpoint, worker, __version__, RequestForwarder, State, wait
 from .util import Host
 from . import slack
 
@@ -169,7 +161,6 @@ class Master:
 
         self.sanic_app.register_listener(start_slack_log, "before_server_start")
         self.sanic_app.register_listener(stop_slack_log, "after_server_stop")
-
 
         debug = self.log_level == "DEBUG"
 

--- a/coco/slack.py
+++ b/coco/slack.py
@@ -1,31 +1,220 @@
 """
-coco slack module.
+coco slack logging module.
 
 Exports messages to slack.
+
+Modified from <https://github.com/imbolc/aiolog> and
+<https://github.com/founders4schools/python-webhook-logger>
 """
-import requests
+
+# Copyright (c) 2011 Imbolc.
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
-class SlackExporter:
-    """Slack exporter: sends messages to slack."""
+import logging
+import asyncio
+import aiohttp
 
-    def __init__(self, webhook_url):
-        self.url = webhook_url
 
-    def send(self, msg, channel=None):
-        """
-        Send a slack message.
+class HTTPPostQueue:
+    """An async queue for sending HTTP Post requests.
+
+    Parameters
+    ----------
+    queue_size : int
+        Maximum queue length.
+    timeout : int
+        Timeout for HTTP requests in seconds.
+    """
+
+    def __init__(self, queue_size=1000, timeout=60):
+        self.queue = None
+        self.queue_size = queue_size
+        self.timeout = timeout
+        self.started = False
+
+    def start(self, loop):
+        """Start up the loop processing PUSH messages.
 
         Parameters
         ----------
-        msg : str
-            The message.
-        channel : str
-            The slack channel (without `#`). Optional, default is implied in the Slack API token.
+        loop : asyncio.loop
+            The event loop to use.
         """
-        if not self.url:
-            return
-        data = {"text": msg}
-        if channel:
-            data["channel"] = channel
-        r = requests.post(self.url, json=data)
+        self.loop = loop
+        self.queue = asyncio.Queue(maxsize=self.queue_size, loop=loop)
+        self.task = asyncio.ensure_future(self.consume(), loop=loop)
+        self.started = True
+        self.STOP_SIGNAL = object()
+
+    def push(self, url, payload):
+        """Place an item into the PUSH queue.
+
+        Parameters
+        ----------
+        url : string
+            URL to push to.
+        payload : dict
+            Data to push.
+        """
+        if self.started:
+            self.queue.put_nowait((url, payload))
+
+    async def stop(self, timeout=60):
+        """Stop the queue processing.
+
+        Parameters
+        ----------
+        timeout : int
+            Seconds to wait before just cancelling queued messages.
+        """
+        with asyncio.suppress(asyncio.TimeoutError):
+            with asyncio.timeout_manager(timeout, loop=self.loop):
+                await self.queue.put(self.STOP_SIGNAL)
+                await self.queue.join()
+                while self.started:
+                    await asyncio.sleep(0.1, loop=self.loop)
+        self.task.cancel()
+
+    async def consume(self):
+        """Process the queue of messages."""
+        time_to_stop = False
+        while not time_to_stop:
+            entry = await self.queue.get()
+            self.queue.task_done()
+
+            # Exit if requested
+            if entry is self.STOP_SIGNAL:
+                break
+
+            # Process the item
+            await self.process_item(entry)
+
+    async def process_item(self, entry):
+        """Process a queue item.
+
+        Parameters
+        ----------
+        entry : tuple
+            URL, payload tuple.
+        """
+
+        url, data = entry
+
+        async with aiohttp.ClientSession(loop=self.loop) as session:
+            async with session.post(url, json=data) as response:
+                if response.status != 200:
+                    # TODO: log to a real logger at this point
+                    pass
+
+
+class TestQueue(HTTPPostQueue):
+    """Simple test queue that prints what gets pushed to it."""
+    async def process_item(self, entry):
+        print(entry)
+
+
+# MIT License
+#
+# Copyright (c) 2017, Founders4Schools
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+class SlackLogHandler(logging.Handler):
+    """Logging handler to post to Slack."""
+
+    # NOTE: Class level queue for posting, be careful about changing this. You
+    # probably want to make sure you do this at class level
+    #queue = TestQueue()
+    queue = HTTPPostQueue()
+
+    def __init__(self, hook_url, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.hook_url = hook_url
+        self.formatter = SlackLogFormatter()
+
+    def emit(self, record):
+        """
+        Submit the record with a POST request
+        """
+        try:
+            payload = self.format(record)
+            self.queue.push(self.hook_url, payload)
+        except Exception:
+            self.handleError(record)
+
+    def filter(self, record):
+        """
+        Disable the logger if hook_url isn't defined,
+        we don't want to do it in all environments (e.g local/CI)
+        """
+        if not self.hook_url:
+            return 0
+        return super().filter(record)
+
+
+class SlackLogFilter(logging.Filter):
+    """
+    Logging filter to decide when logging to Slack is requested, using
+    the `extra` kwargs:
+        `logger.info("...", extra={'notify_slack': True})`
+    """
+
+    def filter(self, record):
+        return getattr(record, 'notify_slack', False)
+
+
+class SlackLogFormatter(logging.Formatter):
+
+    def __init__(self, title=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.title = title
+
+    def format(self, record):
+        """
+        Format message content, timestamp when it was logged and a
+        coloured border depending on the severity of the message
+        """
+        ret = {
+            'ts': record.created,
+            'text': record.getMessage(),
+            'title': record.name if self.title is None else self.title
+        }
+        try:
+            loglevel_colour = {
+                'INFO': 'good',
+                'WARNING': 'warning',
+                'ERROR': '#E91E63',
+                'CRITICAL': 'danger',
+            }
+            ret['color'] = loglevel_colour[record.levelname]
+        except KeyError:
+            pass
+        return {'attachments': [ret]}

--- a/coco/worker.py
+++ b/coco/worker.py
@@ -13,8 +13,9 @@ import sys
 from . import Result
 from .scheduler import Scheduler
 from .exceptions import CocoException, InvalidMethod, InvalidPath, InvalidUsage
+from .slack import SlackLogHandler
 
-logger = logging.getLogger("asyncio")
+logger = logging.getLogger(__name__)
 
 
 def signal_handler(sig, frame):
@@ -145,6 +146,9 @@ def main_loop(endpoints, forwarder, coco_port, metrics_port, log_level):
     # issues involving the asyncio event loop and the Process fork
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
+
+    # Start up slack logging for the worker
+    SlackLogHandler.queue.start(loop)
 
     scheduler = Scheduler(endpoints, "localhost", coco_port, log_level)
     loop.run_until_complete(asyncio.gather(go(), scheduler.start()))

--- a/conf/coco.conf
+++ b/conf/coco.conf
@@ -18,7 +18,6 @@ groups:
         - localhost:12000
         - recv1:12048
         - recv2:12048
-slack_webhook: https://hooks.slack.com/services/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
 comet_broker:
     enabled: True
     host: recv1
@@ -27,7 +26,7 @@ load_state:
     cluster: "../conf/gpu.yaml"
     receiver: "../conf/recv.yaml"
 
-slack_webhook: https://webhookurl.com/jjjj/
+slack_token: "slack_bot_token"
 slack_rules:
   - logger: coco
     level: WARNING

--- a/conf/coco.conf
+++ b/conf/coco.conf
@@ -26,3 +26,13 @@ comet_broker:
 load_state:
     cluster: "../conf/gpu.yaml"
     receiver: "../conf/recv.yaml"
+
+slack_webhook: https://webhookurl.com/jjjj/
+slack_rules:
+  - logger: coco
+    level: WARNING
+    channel: coco-alerts
+
+  - logger: coco.endpoint.update-pulsar-pointing-0
+    level: INFO
+    channel: pulsar-timing-ops

--- a/scripts/coco-client
+++ b/scripts/coco-client
@@ -55,7 +55,7 @@ def load_endpoints(endpoint_path):
                     print("coco-client: Failure reading YAML file {}: {}"
                           .format(endpoint_file, exc))
             conf["state"] = None
-            ee[name] = Endpoint(name, conf, None, None, None)
+            ee[name] = Endpoint(name, conf, None, None)
     return ee
 
 


### PR DESCRIPTION
This adds the ability to output to slack via the standard python
logging framework, using a custom async SlackLogHandler. Logging can be
customised in the config files by specifying rules for how to dispatch
logging messages to slack rooms.

This also gives each endpoint its own individual logger for fine grained
control of logging output, and removes the legacy slack support.