### PR TITLE
feat(endpoint): add top-level success to response

### DIFF
--- a/coco/request_forwarder.py
+++ b/coco/request_forwarder.py
@@ -56,12 +56,11 @@ class Forward:
         if not hosts:
             hosts = self.group
         forward_result = await self.forward_function(self.name, method, request, hosts, params)
-        success = True
         if self.check:
             for check in self.check:
-                success &= await check.run(forward_result)
+                forward_result.success &= await check.run(forward_result)
 
-        return success, forward_result
+        return forward_result
 
     def forward_function(self, **kwargs):
         """Pure virtual method, only use overwriting methods from sub classes."""

--- a/coco/result.py
+++ b/coco/result.py
@@ -66,6 +66,7 @@ class Result:
         self._state = dict()
         self._embedded = dict()
         self._checks = dict()
+        self._success = True
 
     @property
     def name(self) -> str:
@@ -78,6 +79,30 @@ class Result:
             Name.
         """
         return self._name
+
+    @property
+    def success(self) -> bool:
+        """
+        Get result success.
+
+        Returns
+        -------
+        bool
+            True if successful, otherwise False.
+        """
+        return self._success
+
+    @success.setter
+    def success(self, value):
+        """
+        Set the result success.
+
+        Parameters
+        ----------
+        value : bool
+            True if successful, otherwise False.
+        """
+        self._success = value
 
     def result(self, name: str) -> Dict:
         """
@@ -141,6 +166,7 @@ class Result:
         """
         if not result:
             return
+        self._success &= result.success
         self._result.update(result._result)
         self._status.update(result._status)
         self._checks.update(result._checks)
@@ -238,6 +264,8 @@ class Result:
 
         if self._msg:
             d["message"] = self._msg
+
+        d["success"] = self._success
 
         if self._error:
             d["error"] = self._error
@@ -353,6 +381,7 @@ class Result:
         elif isinstance(result, dict):
             self._embedded[name] = Result(name, result, error)
         elif isinstance(result, Result):
+            self._success &= result.success
             self._embedded[name] = result
         else:
             msg = f"Failure embedding results of /{name}."

--- a/tests/test_call_coco.py
+++ b/tests/test_call_coco.py
@@ -50,6 +50,7 @@ def test_forward(farm, runner):
         assert farm.counters()[p][ENDPT_NAME2] == 1
     assert ENDPT_NAME in response
     assert ENDPT_NAME2 in response
+    assert response["success"] == True
     for h in farm.hosts:
         assert h in response[ENDPT_NAME2][ENDPT_NAME2]
         assert "status" in response[ENDPT_NAME2][ENDPT_NAME2][h]

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -97,6 +97,7 @@ def test_forward(farm, runner):
         assert farm.counters()[p]["pong"] == 1
 
     # Check failure report
+    assert response["success"] is False
     failed_host = list(response["failed_checks"]["pong"].keys())
     assert len(failed_host) == N_HOSTS
     reply = response["failed_checks"]["pong"][failed_host[0]]["reply"]
@@ -109,6 +110,7 @@ def test_forward(farm, runner):
         assert farm.counters()[p]["pong"] == 2
 
     # Check failure report
+    assert response["success"] is True
     assert "failed_checks" not in response
 
     # Test failed value check
@@ -116,6 +118,7 @@ def test_forward(farm, runner):
     response = runner.client("value_check", request)
     for p in farm.ports:
         assert farm.counters()[p]["pong"] == 3
+    assert response["success"] is False
 
     request = {"ok": False}
     response = runner.client("value_check", request)
@@ -123,6 +126,7 @@ def test_forward(farm, runner):
         assert farm.counters()[p]["pong"] == 4
 
     # Check failure report
+    assert response["success"] is False
     failed_host = list(response["failed_checks"]["pong"].keys())
     assert len(failed_host) == N_HOSTS
     reply = response["failed_checks"]["pong"][failed_host[0]]["reply"]
@@ -135,6 +139,7 @@ def test_forward(farm, runner):
         assert farm.counters()[p]["pong"] == 5
 
     # Check failure report
+    assert response["success"] is True
     assert "failed_checks" not in response
 
     # Test failed identical check
@@ -144,6 +149,7 @@ def test_forward(farm, runner):
         assert farm.counters()[p]["rand"] == 1
 
     # Check failure report
+    assert response["success"] is False
     failed_host = list(response["failed_checks"]["rand"].keys())
     assert len(failed_host) == N_HOSTS
     reply = response["failed_checks"]["rand"][failed_host[0]]["reply"]
@@ -156,6 +162,7 @@ def test_forward(farm, runner):
         assert farm.counters()[p]["rand"] == 2
 
     # Check failure report
+    assert response["success"] is True
     assert "failed_checks" not in response
 
     # Test failed check on before
@@ -165,6 +172,7 @@ def test_forward(farm, runner):
         assert farm.counters()[p]["pong"] == 6
 
     # Check failure report
+    assert response["success"] is False
     failed_host = list(response["pong"]["failed_checks"]["pong"].keys())
     assert len(failed_host) == N_HOSTS
     reply = response["pong"]["failed_checks"]["pong"][failed_host[0]]["reply"]
@@ -177,6 +185,7 @@ def test_forward(farm, runner):
         assert farm.counters()[p]["pong"] == 7
 
     # Check failure report
+    assert response["success"] is False
     failed_host = list(response["pong"]["failed_checks"]["pong"].keys())
     assert len(failed_host) == N_HOSTS
     reply = response["pong"]["failed_checks"]["pong"][failed_host[0]]["reply"]

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -56,6 +56,16 @@ def test_forward(farm, runner):
         assert farm.counters()[p][ENDPT_NAME] == N_CALLS + 1
 
 
+def test_wrong_vars(farm, runner):
+    request = {"foo": "dfg", "bar": 1337}
+    response = requests.get(f"http://localhost:{PORT}/{ENDPT_NAME}", json=request)
+    assert response.status_code == 400
+
+    request = {"foo": 1337}
+    response = requests.get(f"http://localhost:{PORT}/{ENDPT_NAME}", json=request)
+    assert response.status_code == 400
+
+
 def test_url_args(farm, runner):
     """Test if URL arguments get forwarded to an external endpoint."""
     request = {"foo": 0, "bar": "1337"}


### PR DESCRIPTION
If any check failed the reponse will have a top-level success value set
to False.

If the variables in a request don't match the coco config, a HTTP status
code 400 is returned.

Closes #111