### PR TITLE
switch to ujson

### DIFF
--- a/coco/endpoint.py
+++ b/coco/endpoint.py
@@ -4,7 +4,7 @@ from copy import copy
 import time
 from typing import Optional, Callable, Union, List, Dict
 
-import orjson as json
+import ujson as json
 from pydoc import locate
 import requests
 import sanic

--- a/coco/master.py
+++ b/coco/master.py
@@ -11,7 +11,7 @@ import os
 from pathlib import Path
 from multiprocessing import Process
 
-import orjson as json
+import ujson as json
 import redis
 import aioredis
 

--- a/coco/metric.py
+++ b/coco/metric.py
@@ -4,7 +4,6 @@ coco metric module.
 Helper functions for prometheus metric exporting.
 """
 
-import re
 import threading
 from prometheus_client.exposition import (
     MetricsHandler,

--- a/coco/worker.py
+++ b/coco/worker.py
@@ -6,7 +6,7 @@ This module implements coco's worker. It runs in it's own process and empties th
 import asyncio
 import aioredis
 import logging
-import orjson as json
+import ujson as json
 import signal
 import sys
 from urllib.parse import parse_qsl

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 comet @ git+https://github.com/chime-experiment/comet.git
 aiohttp
-orjson
+ujson
 pyyaml
 requests
 sanic

--- a/tests/test_set_state.py
+++ b/tests/test_set_state.py
@@ -1,6 +1,5 @@
 """Test endpoint config option `set_state` and `get_state`."""
 import pytest
-import orjson as json
 
 from coco.test import coco_runner, endpoint_farm
 from coco.state import State

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -1,6 +1,5 @@
 """Test basic endpoint call forwarding with timeout."""
 import pytest
-import requests
 import time
 
 from coco.test import coco_runner


### PR DESCRIPTION
use ujson instead of orjson

This is just to make the first deployment easier. should be reverted
later.