### PR TITLE
fix(state): throw away empty strings in get_state path

### DIFF
--- a/coco/state.py
+++ b/coco/state.py
@@ -92,7 +92,10 @@ class State:
             the values in the requested entry.
         """
         value = self.read(path)
+
+        # parse the path: split it at slashes and throw away empty parts
         parts = path.split("/")
+        parts = list(filter(lambda part: part != "", parts))
 
         def pack(p: List[str], v) -> dict:
             """


### PR DESCRIPTION
Requesting `/` with get_state in an endpoint config resulted in
`state.extract` to split the path into `['', '']` and therefor in a
strange reply. Throwing away empty strings after splitting seems to fix
this.