### PR TITLE
fix(request_forwarder): copy request for coco forwards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,4 +46,4 @@ script:
     - cd ..
 
     # Run unit tests
-    - PYTHONPATH=. pytest  --cov-report term-missing:skip-covered --cov=coco tests/test_*.py
+    - PYTHONPATH=. pytest -xs --cov-report term-missing:skip-covered --cov=coco tests/test_*.py

--- a/coco/request_forwarder.py
+++ b/coco/request_forwarder.py
@@ -223,6 +223,8 @@ class RequestForwarder:
         :class:`Result`
             Reply of endpoint call.
         """
+        # the request data gets popped in endpoint.call(), so we give them a copy only
+        request = copy.copy(request)
         return await self._endpoints[name].call(request=request, hosts=hosts)
 
     async def _request(self, session, method, host, endpoint, request, params):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -98,3 +98,5 @@ def test_sched(farm, runner):
         assert counters[p]["scheduled-check-val"] == num_sched
         assert "scheduled-fail-type" not in counters[p]
         assert "scheduled-fail-val" not in counters[p]
+
+    runner.stop_coco()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -85,7 +85,7 @@ def test_sched(farm, runner):
     """Test if scheduled endpoints are called when they should be."""
     start_t = time.time()
     # Let three periods pass
-    time.sleep(3 * PERIOD)
+    time.sleep(3 * PERIOD + 0.5)
 
     counters = farm.counters()
     end_t = time.time()

--- a/tests/test_set_state.py
+++ b/tests/test_set_state.py
@@ -1,5 +1,6 @@
 """Test endpoint config option `set_state` and `get_state`."""
 import pytest
+import time
 
 from coco.test import coco_runner, endpoint_farm
 from coco.state import State
@@ -85,6 +86,10 @@ def runner(farm):
 
 def test_get_state(runner):
     """Test get/set_state."""
+
+    # wait a moment to make sure coco is ready
+    time.sleep(1)
+
     # Set state to True
     runner.client(SET_ENDPT_NAME)
 

--- a/tests/test_wait.py
+++ b/tests/test_wait.py
@@ -11,7 +11,7 @@ GET_TS_ENDPT_NAME = "get_ts_endpt"
 TS_PATH = "timestamps/test"
 CONFIG = {"log_level": "INFO"}
 T_WAIT = 2
-T_HOW_SLOW_IS_COCO = 1
+T_HOW_SLOW_IS_COCO = 1.5
 ENDPOINTS = {
     ENDPT_NAME: {
         "group": "test",


### PR DESCRIPTION
The request data gets popped in endpoint.call, so we need to hand them a
copy only.

Fixes #171