### PR TITLE
add option: exclude_from_reset

### DIFF
--- a/coco/config.py
+++ b/coco/config.py
@@ -85,6 +85,11 @@ Example config:
         - logger: coco.endpoint.update-pulsar-pointing-0
           level: INFO
           channel: pulsar-timing-ops
+
+    # State paths to be excluded from reset.
+    exclude_from_reset:
+        - this/should/be/preserved
+        - this_too
 """
 import logging
 import os
@@ -131,6 +136,7 @@ _config_skeleton = {
     "queue_length": DefaultValue(0),
     "timeout": DefaultValue("10s"),
     "frontend_timeout": DefaultValue("10m"),
+    "exclude_from_reset": DefaultValue([]),
 }
 
 

--- a/coco/exceptions.py
+++ b/coco/exceptions.py
@@ -58,3 +58,9 @@ class ConfigError(CocoException):
     """Exception for errors found in the config."""
 
     status_code = 500
+
+
+class InternalError(CocoException):
+    """Exception for coco internal errors."""
+
+    status_code = 500

--- a/coco/master.py
+++ b/coco/master.py
@@ -214,7 +214,7 @@ class Master:
             host="0.0.0.0",
             port=self.config["port"],
             workers=self.config["n_workers"],
-            debug=debug,
+            debug=False,
             access_log=debug,
         )
 

--- a/coco/master.py
+++ b/coco/master.py
@@ -303,7 +303,10 @@ class Master:
 
         # Init state, trys loading from persistent storage
         self.state = State(
-            self.config["log_level"], storage_path, self.config["load_state"]
+            self.config["log_level"],
+            storage_path,
+            self.config["load_state"],
+            self.config["exclude_from_reset"],
         )
 
         # Validate slack posting rules

--- a/coco/scheduler.py
+++ b/coco/scheduler.py
@@ -12,6 +12,7 @@ from aiohttp import request, ClientTimeout
 from sys import exit
 
 from .util import str2total_seconds
+from .exceptions import InternalError
 
 logger = logging.getLogger(__name__)
 
@@ -178,9 +179,9 @@ class EndpointTimer(Timer):
             # Look for value in state
             try:
                 state_val = self.endpoint.state.read(c["path"])
-            except KeyError:
+            except InternalError as e:
                 logger.info(
-                    f"Skipping scheduled endpoint /{self.name} because {c['path']} doesn't exist."
+                    f"Skipping scheduled endpoint /{self.name} because {c['path']} doesn't exist: {e}"
                 )
                 return
             # Check type in state

--- a/coco/state.py
+++ b/coco/state.py
@@ -8,6 +8,7 @@ import msgpack as msgpack
 import yaml
 
 from .util import PersistentState
+from .exceptions import InternalError
 
 logger = logging.getLogger(__name__)
 
@@ -192,7 +193,7 @@ class State:
             try:
                 element = element[paths[i]]
             except KeyError:
-                raise RuntimeError("Path not found in state: {}".format(path))
+                raise InternalError("Path not found in state: {}".format(path))
         return element
 
     def _find_new(self, path):

--- a/coco/state.py
+++ b/coco/state.py
@@ -27,7 +27,11 @@ class State:
     """Representation of the complete state of all hosts (configs) coco controls."""
 
     def __init__(
-        self, log_level, storage_path: os.PathLike, default_state_files: Dict[str, str]
+        self,
+        log_level,
+        storage_path: os.PathLike,
+        default_state_files: Dict[str, str],
+        exclude_from_reset: List[str],
     ):
         """
         Construct the state.
@@ -40,8 +44,11 @@ class State:
             Path to the persistent state storage.
         default_state_files : Dict[str, str]
             Yaml files that are loaded to build the default state. Keys are state paths.
+        exclude_from_reset : List[str]
+            State paths that should be preserved during reset.
         """
         self.default_state_files = default_state_files
+        self.exclude_from_reset = exclude_from_reset
 
         # Initialise persistent storage
         self._storage = PersistentState(storage_path)
@@ -215,7 +222,11 @@ class State:
         paths = path.split("/")
         element = self._storage.state
         for i in range(0, len(paths) - 1):
-            element = element[paths[i]]
+            try:
+                element = element[paths[i]]
+            except KeyError:
+                element[paths[i]] = dict()
+                element = element[paths[i]]
         return element, paths[-1]
 
     def find_or_create(self, path):
@@ -333,7 +344,22 @@ class State:
 
         Clear the internal state and re-load YAML files to restore default state.
         """
+        # back up excluded paths
+        excluded = dict()
+        for path in self.exclude_from_reset:
+            split_path = path.split("/")
+            element = self._storage.state
+            for i in range(0, len(split_path)):
+                element = element[split_path[i]]
+            excluded[path] = element
+
         # Reset persistent state
         with self._storage.update():
             self._storage.state = dict()
         self._load_default_state()
+
+        # recover excluded paths
+        for path, content in excluded.items():
+            with self._storage.update():
+                location, new_entry = self._find_new(path)
+                location[new_entry] = content

--- a/coco/test/coco_runner.py
+++ b/coco/test/coco_runner.py
@@ -37,7 +37,6 @@ class Runner:
     def __del__(self):
         """Destructor."""
         self.client("reset-state", silent=True)
-        time.sleep(0.5)
         self.stop_coco()
 
     def client(self, command, data=None, silent=False):

--- a/coco/test/coco_runner.py
+++ b/coco/test/coco_runner.py
@@ -29,9 +29,7 @@ class Runner:
     """Coco Runner for unit tests."""
 
     def __init__(self, config, endpoints):
-        self.coco, self.configfile, self.endpointdir = self.start_coco(
-            config, endpoints
-        )
+        self.start_coco(config, endpoints)
         time.sleep(1)
 
     def __del__(self):
@@ -55,25 +53,25 @@ class Runner:
         result = json.loads(result)
         return result
 
-    @staticmethod
-    def start_coco(config, endpoint_configs):
+    def start_coco(self, config, endpoint_configs):
         """Start coco with a given config."""
         CONFIG.update(config)
 
         # Write endpoint configs to file
-        endpointdir = tempfile.TemporaryDirectory()
-        CONFIG["endpoint_dir"] = endpointdir.name
+        self.endpointdir = tempfile.TemporaryDirectory()
+        CONFIG["endpoint_dir"] = self.endpointdir.name
         for name, endpoint_conf in endpoint_configs.items():
-            with open(os.path.join(endpointdir.name, name + ".conf"), "w") as outfile:
+            with open(
+                os.path.join(self.endpointdir.name, name + ".conf"), "w"
+            ) as outfile:
                 json.dump(endpoint_conf, outfile)
 
         # Write config to file
-        configfile = tempfile.NamedTemporaryFile("w")
-        json.dump(CONFIG, configfile)
-        configfile.flush()
+        self.configfile = tempfile.NamedTemporaryFile("w")
+        json.dump(CONFIG, self.configfile)
+        self.configfile.flush()
 
-        coco = subprocess.Popen([COCO, "-c", configfile.name])
-        return coco, configfile, endpointdir
+        self.coco = subprocess.Popen([COCO, "-c", self.configfile.name])
 
     def stop_coco(self):
         """Stop coco script."""

--- a/coco/test/endpoint_farm.py
+++ b/coco/test/endpoint_farm.py
@@ -5,6 +5,7 @@ Simulates multiple hosts with endpoints.
 """
 
 from flask import Flask, request, jsonify
+import os
 import threading
 import requests
 import socket
@@ -105,6 +106,9 @@ class Farm:
 
         callbacks = _callbacks
         ports = list()
+
+        # Tell flask that this is not a prod environment
+        os.environ["FLASK_ENV"] = "development"
 
         for i in range(n_ports):
             port = find_free_port()

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -94,3 +94,6 @@ frontend_timeout: str
     layered forward calls you should increase this.
     A string representing a timedelta in the form `<int>h`, `<int>m`,
     `<int>s` or a combination of the three. Default `10m`.
+exclude_from_reset: list
+    A list of strings that are state paths to be excluded from state resets. Default:
+    `None`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1,0 +1,96 @@
+Configuration
+================================
+
+coco's main configuration file has the following options. It can be passed to coco with `coco[d] -c path/to/coco.conf`.
+
+log_level : `str`
+    The global log level. Can be one of `CRITICAL`, `ERROR`, `WARNING`, `INFO` or `DEBUG`. Default `INFO`.
+host: `str`
+    Host the coco server (`cocod`) is run on.
+port: `int`
+    Port the coco server (`cocod`) should be run on. Default `12055`.
+metrics_port: `int`
+    Port cocod should run its metrics server on. Default `9090`.
+endpoint_dir: `str`
+    Path where endpoint config files are located.
+n_workers: `int`
+    Number of sanic workers to start for the frontend of `cocod`. Default `1`.
+session_limit: `int`
+    Maximum number of tasks being executed concurrently by request forwarder. A higher number will use more memory. Default `1000`.
+blacklist_path: `str`
+    Path to persistent blacklist storage file. Default `/var/lib/coco/blacklist.json`.
+storage_path: `str`
+    Path to persistent state storage. Default `/var/lib/coco/state/`.
+groups:
+    Groups of nodes that are managed by coco. Contains key-value pairs where the key is
+    the name of the group (`str`) and the value is a list of `str` in the format
+    `host:port`.
+
+    Example:
+
+.. code-block:: yaml
+
+    groups:
+        gps_server:
+            - carillon.chime:54321
+        cluster:
+            - localhost:12050
+            - localhost:12000
+        receiver_nodes:
+            - recv1:12048
+            - recv2:12048
+        all:
+            - localhost:12050
+            - localhost:12000
+            - recv1:12048
+            - recv2:12048
+
+load_state:
+    Initial cluster state.
+    Contains key-value pairs that are state paths and file system paths. The files
+    located at the latter locations are loaded into the prior parts of the state when
+    resetting the state. Default: `None`.
+
+    Example:
+
+.. code-block:: yaml
+
+    load_state:
+        cluster: "../conf/gpu.yaml"
+        receiver: "../conf/recv.yaml"
+
+slack_token: `str`
+    Slack authorization token. Default: `None`.
+slack_rules: list
+    Rules for dispatching logging messages to slack.
+    These specify the logger path, the minimum level it applies to and the
+    slack channel the messages should go to. Default: `None`.
+
+    Example:
+
+.. code-block:: yaml
+
+    slack_rules:
+
+        - logger: coco
+          level: WARNING
+          channel: coco-alerts
+
+        - logger: coco.endpoint.update-pulsar-pointing-0
+          level: INFO
+          channel: pulsar-timing-ops
+
+queue_length: int
+    Length of the endpoint request queue between front- end backend, managed by redis.
+    Default `0`.
+timeout: str
+    Time before requests sent to nodes time out.
+    A string representing a timedelta in the form `<int>h`, `<int>m`,
+    `<int>s` or a combination of the three. Default `10s`.
+frontend_timeout: str
+    Time before requests sent to coco time out.
+    This value should depend on how many layers your configuration files have. If a call
+    to a coco endpoint could take longer than this value, because it triggers many
+    layered forward calls you should increase this.
+    A string representing a timedelta in the form `<int>h`, `<int>m`,
+    `<int>s` or a combination of the three. Default `10m`.

--- a/docs/endpoint.rst
+++ b/docs/endpoint.rst
@@ -74,7 +74,7 @@ timestamp : str
 
 
 Forwards
-==========
+---------
 A forward is described by the configuration as either a `str` or `dict`.
 
 A `str` would just be the name of the endpoint to forward to. this can be internal (a coco endpoint
@@ -101,10 +101,10 @@ save_reply_to_state : str
 
 
 Checks
-================================
+-------
 
 Reply Checks
---------------
+`````````````
 
 If the variables don't match in the reply from any host, the forwarding will be considered failed
 for these hosts.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@ in sync on the hosts.
    :caption: Configuration:
    :maxdepth: 2
 
+   config
    endpoint
 
 Indices and tables

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -4,7 +4,6 @@ from aiohttp import request
 import requests
 import asyncio
 from prometheus_client.parser import text_string_to_metric_families
-import time
 
 from coco.test import coco_runner
 from coco.test import endpoint_farm
@@ -47,7 +46,6 @@ def farm():
 def runner(farm):
     """Create a coco runner."""
     CONFIG["groups"] = {"test": farm.hosts}
-    time.sleep(1)
     return coco_runner.Runner(CONFIG, ENDPOINTS)
 
 
@@ -63,7 +61,6 @@ async def _client(config, endpoint, sleep=None):
 def test_queue(farm, runner):
     """Test queue limit."""
     # Wait for coco to start up
-    time.sleep(1)
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     # Set up client tasks

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -11,7 +11,7 @@ CONFIG = {"log_level": "DEBUG"}
 STATE_PATH = "test/success"
 STATE_PATH_FAIL_TYPE = "test/fail_type"
 STATE_PATH_FAIL_VAL = "test/fail_val"
-PERIOD = 1
+PERIOD = 1.5
 ENDPOINTS = {
     "scheduled": {"group": "test", "schedule": {"period": PERIOD}},
     "scheduled-check-type": {

--- a/tests/test_set_state.py
+++ b/tests/test_set_state.py
@@ -1,6 +1,5 @@
 """Test endpoint config option `set_state` and `get_state`."""
 import pytest
-import time
 
 from coco.test import coco_runner, endpoint_farm
 from coco.state import State
@@ -97,9 +96,6 @@ def runner(farm):
 
 def test_get_state(runner):
     """Test get/set_state."""
-
-    # wait a moment to make sure coco is ready
-    time.sleep(1)
 
     # Set state to True
     runner.client(SET_ENDPT_NAME)


### PR DESCRIPTION
Add global config option exclude_from_reset: a list of state paths that
should be preserved during state reset.

Fixes #177 