### PR TITLE
Add metric for tracking how long a request is waiting in the queue

### DIFF
--- a/coco/master.py
+++ b/coco/master.py
@@ -98,7 +98,7 @@ class Master:
             """ if redis.call('llen', KEYS[1]) >= tonumber(ARGV[1]) then
                         return true
                     else
-                        redis.call('hmset', KEYS[2], ARGV[2], ARGV[3], ARGV[4], ARGV[5], ARGV[6], ARGV[7], ARGV[8], ARGV[9])
+                        redis.call('hmset', KEYS[2], ARGV[2], ARGV[3], ARGV[4], ARGV[5], ARGV[6], ARGV[7], ARGV[8], ARGV[9], ARGV[10], ARGV[11])
                         redis.call('rpush', KEYS[1], KEYS[2])
                         return false
                     end
@@ -392,7 +392,8 @@ class Master:
         Master endpoint. Passes all endpoint calls on to redis and blocks until completion.
         """
         # create a unique name for this task: <process ID>-<POSIX timestamp>
-        name = f"{os.getpid()}-{time.time()}"
+        now = time.time()
+        name = f"{os.getpid()}-{now}"
 
         with await self.redis_async as r:
             # Check if queue is full. If not, add this task.
@@ -410,6 +411,8 @@ class Master:
                         request.body,
                         "params",
                         request.query_string,
+                        "received",
+                        now,
                     ],
                 )
 
@@ -431,6 +434,8 @@ class Master:
                     request.body,
                     "params",
                     request.query_string,
+                    "received",
+                    now,
                 )
 
                 # Add task name to queue

--- a/coco/request_forwarder.py
+++ b/coco/request_forwarder.py
@@ -7,7 +7,7 @@ from typing import Iterable
 
 import aiohttp
 import redis
-from prometheus_client import Counter, Gauge
+from prometheus_client import Counter, Gauge, Histogram
 
 from . import TaskPool
 from .metric import start_metrics_server
@@ -195,6 +195,10 @@ class RequestForwarder:
         )
         self.queue_len = Gauge(
             "coco_queue_length", f"Length of queue storing coco requests.", unit="total"
+        )
+        self.queue_wait_time = Histogram(
+            "coco_queue_wait_time", "Length of time the request is in the queue before being processed",
+            ["endpoint"], unit="seconds"
         )
         for edpt in self._endpoints:
             self.dropped_counter.labels(endpoint=edpt).inc(0)

--- a/coco/request_forwarder.py
+++ b/coco/request_forwarder.py
@@ -197,8 +197,10 @@ class RequestForwarder:
             "coco_queue_length", f"Length of queue storing coco requests.", unit="total"
         )
         self.queue_wait_time = Histogram(
-            "coco_queue_wait_time", "Length of time the request is in the queue before being processed",
-            ["endpoint"], unit="seconds"
+            "coco_queue_wait_time",
+            "Length of time the request is in the queue before being processed",
+            ["endpoint"],
+            unit="seconds",
         )
         for edpt in self._endpoints:
             self.dropped_counter.labels(endpoint=edpt).inc(0)

--- a/coco/worker.py
+++ b/coco/worker.py
@@ -90,7 +90,9 @@ def main_loop(
             )
             if received:
                 received = float(received)
-                forwarder.queue_wait_time.labels(endpoint_name).observe(time.time()-received)
+                forwarder.queue_wait_time.labels(endpoint_name).observe(
+                    time.time() - received
+                )
 
             await conn.execute("del", name)
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -89,7 +89,7 @@ def test_metrics(farm, runner):
         assert count_forward[ind].value == N_CALLS
         assert farm.counters()[p][ENDPT_NAME_FWD] == N_CALLS
 
-    # Expect only queue wait time for "status", because that's what `/metrics` gets routed to
+    # Expect only queue wait time for "status", because that's all the test calls
     assert len(count_wait_time) == 1
     assert count_wait_time["status"].value == 2
 


### PR DESCRIPTION
This works by adding another attribute "received" to the Redis object that
serializes the request, and using that attribute when the request is being
handled by a worker to calculate the time it spent in the queue. This time is
recorded in a Prometheus histogram metric `coco_queue_wait_time`, with a label
for the "endpoint".