### PR TITLE
Options to load and save states

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,9 @@ script:
     # Run black on all .py files in all subfolders
     - black --check --exclude kotekan .
 
+    # Run black on scripts
+    - black --check scripts/cocod scripts/coco
+
     # Run pydocstyle on all .py files
     - find . -type d \( -path ./docs -o -path ./tests/simulate-chime \) -prune -o ! -name versioneer.py ! -name test_*.py ! -name _version.py -name \*.py -exec pydocstyle --convention=numpy --add-ignore=D105,D202 {} +
 

--- a/coco/master.py
+++ b/coco/master.py
@@ -67,7 +67,7 @@ class Master:
 
         if reset is True:
             # Reset the internal state
-            asyncio.run(self.state.process_post())
+            asyncio.run(self.state.reset_state())
 
         # Configure the forwarder
         try:
@@ -352,8 +352,11 @@ class Master:
 
         endpoints = {
             "blacklist": ("GET", self.forwarder.blacklist.process_get),
-            "reset-state": ("POST", self.state.process_post),
             "update-blacklist": ("POST", self.forwarder.blacklist.process_post),
+            "saved-states": ("GET", self.state.get_saved_states),
+            "reset-state": ("POST", self.state.reset_state),
+            "save-state": ("POST", self.state.save_state),
+            "load-state": ("POST", self.state.load_state),
             "wait": ("POST", wait.process_post),
         }
 

--- a/coco/master.py
+++ b/coco/master.py
@@ -30,7 +30,7 @@ from . import (
     State,
     wait,
 )
-from .exceptions import ConfigError
+from .exceptions import ConfigError, InternalError
 from .util import Host, str2total_seconds
 from . import slack
 from . import config
@@ -254,29 +254,26 @@ class Master:
         try:
             enable_comet = self.config["comet_broker"]["enabled"]
         except KeyError:
-            logger.error("Missing config value 'comet_broker/enabled'.")
-            exit(1)
+            raise ConfigError("Missing config value 'comet_broker/enabled'.")
         if enable_comet:
             try:
                 comet_host = self.config["comet_broker"]["host"]
                 comet_port = self.config["comet_broker"]["port"]
             except KeyError as exc:
-                logger.error(
+                raise InternalError(
                     "Failure registering initial config with comet broker: 'comet_broker/{}' "
                     "not defined in config.".format(exc[0])
                 )
-                exit(1)
             comet = Manager(comet_host, comet_port)
             try:
                 comet.register_start(datetime.datetime.utcnow(), __version__)
                 comet.register_config(self.config)
             except CometError as exc:
-                logger.error(
+                raise InternalError(
                     "Comet failed registering CoCo startup and initial config: {}".format(
                         exc
                     )
                 )
-                exit(1)
         else:
             logger.warning("Config registration DISABLED. This is only OK for testing.")
 
@@ -293,13 +290,17 @@ class Master:
         # relative to the config directory
         self.blacklist_path = Path(self.config["blacklist_path"])
         if not self.blacklist_path.is_absolute():
-            logger.error(
+            raise ConfigError(
                 f"Blacklist path \"{self.config['blacklist_path']}\" must be absolute."
             )
         storage_path = Path(self.config["storage_path"])
         if not storage_path.is_absolute():
-            logger.error(
+            raise ConfigError(
                 f"Storage path \"{self.config['storage_path']}\" must be absolute."
+            )
+        if not storage_path.is_dir():
+            raise ConfigError(
+                f"Storage path \"{self.config['storage_path']}\" doesn't exist."
             )
 
         # Read groups
@@ -365,23 +366,21 @@ class Master:
             if e:
                 for a in e:
                     if isinstance(a, dict):
-                        if not len(a.keys()) is 1:
-                            logger.error(
+                        if len(a.keys()) != 1:
+                            raise ConfigError(
                                 f"coco.endpoint: bad config format for endpoint "
                                 f"`{endpoint.name}`: `{a}`. Should be either a string or "
                                 f"have the format:\n```\nbefore:\n  - endpoint_name:\n   "
                                 f"   identical: True\n```"
                             )
-                            exit(1)
                         a = list(a.keys())[0]
                     if isinstance(a, CocoForward):
                         a = a.name
                     if a not in self.endpoints.keys():
-                        logger.error(
+                        raise ConfigError(
                             f"coco.endpoint: endpoint `{a}` found in config for "
                             f"`{endpoint.name}` does not exist."
                         )
-                        exit(1)
 
         for endpoint in self.endpoints.values():
             if hasattr(endpoint, "before"):

--- a/coco/state.py
+++ b/coco/state.py
@@ -60,6 +60,7 @@ class State:
 
         # If the state storage was empty load state from yaml config files
         if self.is_empty():
+            logger.info("Internal state empty. Loading state from file...")
             self._load_default_state()
 
         logger.setLevel(log_level)
@@ -165,7 +166,7 @@ class State:
         file : str
             Name of the file to read from.
         """
-        logger.debug(f"Loading state {path} from file {file}.")
+        logger.debug(f"Loading file {file} into state path '{path}'.")
 
         # Update persistent state
         with self._storage.update():
@@ -200,7 +201,7 @@ class State:
             try:
                 element = element[paths[i]]
             except KeyError:
-                raise InternalError("Path not found in state: {}".format(path))
+                raise InternalError(f"Path not found in state: {path}")
         return element
 
     def _find_new(self, path):
@@ -380,9 +381,7 @@ class State:
                     element = element[split_path[i]]
                 except KeyError as key:
                     logger.debug(
-                        "Can't exclude {} from config. Path {} not found in state.".format(
-                            key, path
-                        )
+                        f"Can't exclude {key} from config. Path {path} not found in state."
                     )
                     break
             excluded[path] = element

--- a/coco/state.py
+++ b/coco/state.py
@@ -489,8 +489,8 @@ class State:
         name = request.get("name")
         if name == self._name_active_state:
             raise InvalidUsage(
-                f"Can't load state {name}. This name is reserved. Choose one of "
-                f"{self._saved_states}."
+                f"Can't load state {name}. This name is reserved (it's the one that is active now)"
+                f". Choose any other from {self._saved_states}."
             )
         if not self.saved_state_exists(name):
             raise InvalidUsage(

--- a/coco/state.py
+++ b/coco/state.py
@@ -217,9 +217,7 @@ class State:
             return
         for excluded in self.exclude_from_reset:
             if excluded.startswith(path):
-                if len(path) == 0:
-                    excluded = excluded[len(path) :]
-                else:
+                if len(path) != 0:
                     # remove the `/` as well
                     excluded = excluded[len(path) + 1 :]
                 path_first = excluded.split("/")[0]

--- a/coco/state.py
+++ b/coco/state.py
@@ -3,12 +3,14 @@ import collections
 import hashlib
 import logging
 import os
+from pathlib import Path
 from typing import List, Dict
 import msgpack as msgpack
 import yaml
 
-from .util import PersistentState
-from .exceptions import InternalError
+from .result import Result
+from .util import Host, PersistentState
+from .exceptions import InternalError, InvalidUsage
 
 logger = logging.getLogger(__name__)
 
@@ -49,9 +51,19 @@ class State:
         """
         self.default_state_files = default_state_files
         self.exclude_from_reset = exclude_from_reset
+        self._storage_path = storage_path
+        self._name_active_state = "active"
+
+        # List saved states on disk
+        p = Path(self._storage_path).glob("**/*")
+        self._saved_states = [f.name for f in p if f.is_file()]
+        if self._saved_states:
+            logger.info(
+                f"Found {len(self._saved_states)} previously saved states on disk: {self._saved_states}"
+            )
 
         # Initialise persistent storage
-        self._storage = PersistentState(storage_path)
+        self._storage = PersistentState(Path(storage_path, self._name_active_state))
 
         # Update state with content from persistent state loaded from disk
         if not self._storage.state:
@@ -170,13 +182,51 @@ class State:
 
         # Update persistent state
         with self._storage.update():
-            element, name = self._find_new(path)
+            if len(path) != 0:
+                element, name = self._find_new(path)
 
             with open(file, "r") as stream:
                 try:
-                    element[name] = yaml.safe_load(stream)
+                    new_state = yaml.safe_load(stream)
+
+                    # Don't load state parts that are excluded from reset
+                    self._exclude_paths(path, new_state)
+
+                    if len(path) == 0:
+                        self._storage.state = new_state
+                    else:
+                        element[name] = new_state
                 except yaml.YAMLError as exc:
                     logger.error(f"Failure reading YAML file {file}: {exc}")
+
+    def _exclude_paths(self, path, state):
+        """
+        Remove excluded paths from a state (in-place).
+
+        If the excluded paths are set to `foo/bar` and `path` is `foo`, a this function would take
+        a `state = {'bar': 0}` and make it a `state = {}`.
+
+        Parameters
+        ----------
+        path : str
+            Prefix to 'state' when looking for parts to exclude.
+        state : dict
+            The state to remove excluded parts from.
+        """
+        if not isinstance(state, dict):
+            return
+        for excluded in self.exclude_from_reset:
+            if excluded.startswith(path):
+                if len(path) == 0:
+                    excluded = excluded[len(path) :]
+                else:
+                    # remove the `/` as well
+                    excluded = excluded[len(path) + 1 :]
+                path_first = excluded.split("/")[0]
+                if path_first in state:
+                    self._exclude_paths(path_first, state[path_first])
+                if excluded in state:
+                    del state[excluded]
 
     def _find(self, path):
         """
@@ -365,14 +415,119 @@ class State:
         for path, file in self.default_state_files.items():
             self.read_from_file(path, file)
 
-    async def process_post(self, request: dict = None):
+    def saved_state_exists(self, name: str):
+        """Check if a saved state with a given name exists."""
+        if name in self._saved_states:
+            return True
+        else:
+            return False
+
+    async def reset_state(self, request: dict = None):
         """
         Process the POST request to reset the state.
 
         Clear the internal state and re-load YAML files to restore default state.
         """
-        # back up excluded paths
-        excluded = dict()
+        excluded = self._backup_excluded_paths()
+
+        # Reset persistent state
+        with self._storage.update():
+            self._storage.state = dict()
+        self._load_default_state()
+
+        self._recover_excluded_paths(excluded)
+
+    async def save_state(self, request: dict = None):
+        """
+        Process the POST request to save (backup) the state.
+
+        The request dictionary should contain an item with key "name" that holds a string with the
+        name of the saved state.
+        """
+        # get request parameters
+        name = request.get("name", "backup")
+        if name == self._name_active_state:
+            raise InvalidUsage(
+                f"Can't use {self._name_active_state} for saved state. This name is reserved. "
+                f"Choose something else."
+            )
+        overwrite = request.get("overwrite", False)
+
+        # only overwrite an existing state if requested explicitly
+        if self.saved_state_exists(name):
+            if not overwrite:
+                raise InvalidUsage(
+                    f"Saved state '{name}' already exists. Choose something else or try again "
+                    "with 'overwrite=True'."
+                )
+            overwrite = True
+        else:
+            overwrite = False
+
+        # save the active state to <name>
+        saved_state = PersistentState(Path(self._storage_path, name))
+        with saved_state.update():
+            saved_state.state = self._storage.state
+
+        logger.debug(f"Saved state to {Path(self._storage_path, name)}")
+        if not overwrite:
+            # add saved state to index
+            self._saved_states.append(name)
+        return Result(
+            "save-state",
+            result={Host("coco"): (f"Saved state {name}", 200)},
+            type="FULL",
+        )
+
+    async def load_state(self, request: dict = None):
+        """
+        Process the POST request to load a previously saved state.
+
+        Clear the internal state and re-load a state previously saved. Paths under
+        `exclude_from_reset` in the config will not be overwritten by this.
+        """
+
+        # get request parameters
+        name = request.get("name")
+        if name == self._name_active_state:
+            raise InvalidUsage(
+                f"Can't load state {name}. This name is reserved. Choose one of "
+                f"{self._saved_states}."
+            )
+        if not self.saved_state_exists(name):
+            raise InvalidUsage(
+                f"No saved state with name '{name}' exists. Choose one of "
+                f"{self._saved_states}."
+            )
+
+        excluded = self._backup_excluded_paths()
+
+        # Reset persistent state
+        with self._storage.update():
+            self._storage.state = dict()
+        self.read_from_file("", str(Path(self._storage_path, name)))
+
+        self._recover_excluded_paths(excluded)
+        return Result(
+            "load-state",
+            result={Host("coco"): (f"Loaded state {name}", 200)},
+            type="FULL",
+        )
+
+    async def get_saved_states(self, request: dict = None):
+        """
+        Process the GET request to list all saved states.
+
+        Returns a list of previously saved states on disk.
+        """
+        return Result(
+            "saved-states",
+            result={Host("coco"): (self._saved_states, 200)},
+            type="FULL",
+        )
+
+    def _backup_excluded_paths(self):
+        excluded = {}
         for path in self.exclude_from_reset:
             split_path = path.split("/")
             element = self._storage.state
@@ -385,14 +540,10 @@ class State:
                     )
                     break
             excluded[path] = element
+        return excluded
 
-        # Reset persistent state
-        with self._storage.update():
-            self._storage.state = dict()
-        self._load_default_state()
-
-        # recover excluded paths
-        for path, content in excluded.items():
+    def _recover_excluded_paths(self, paths):
+        for path, content in paths.items():
             with self._storage.update():
                 location, new_entry = self._find_new(path)
                 location[new_entry] = content

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ sanic
 aioredis
 async_timeout
 redis
-prometheus_client
+prometheus_client<0.8
 atomicwrites
 mmh3
 deepdiff

--- a/scripts/coco
+++ b/scripts/coco
@@ -12,12 +12,12 @@ STYLES = ["json", "yaml"]
 
 
 def str2bool(v):
-    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+    if v.lower() in ("yes", "true", "t", "y", "1"):
         return True
-    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+    elif v.lower() in ("no", "false", "f", "n", "0"):
         return False
     else:
-        raise argparse.ArgumentTypeError('Boolean value expected.')
+        raise argparse.ArgumentTypeError("Boolean value expected.")
 
 
 def get_endpoints(config):
@@ -34,10 +34,10 @@ parser = argparse.ArgumentParser(description="This is the coco client.")
 
 # Find the endpoints before using argparse
 try:
-    if '-c' in sys.argv:
-        conf = sys.argv[sys.argv.index('-c') + 1]
-    elif '--conf' in sys.argv:
-        conf = sys.argv[sys.argv.index('--conf') + 1]
+    if "-c" in sys.argv:
+        conf = sys.argv[sys.argv.index("-c") + 1]
+    elif "--conf" in sys.argv:
+        conf = sys.argv[sys.argv.index("--conf") + 1]
     else:
         conf = None
 except IndexError:
@@ -49,44 +49,52 @@ endpoints = get_endpoints(coco_config)
 
 # Global options
 parser.add_argument(
-        "-c", "--conf",
-        metavar="PATH",
-        help="read coco.conf file specified by PATH"
-        )
+    "-c", "--conf", metavar="PATH", help="read coco.conf file specified by PATH"
+)
 parser.add_argument(
-        "-r", "--report",
-        metavar="TYPE",
-        help="specify report type (choose from {})".format(result.TYPES),
-        default="CODES_OVERVIEW",
-        choices=result.TYPES
-        )
+    "-r",
+    "--report",
+    metavar="TYPE",
+    help="specify report type (choose from {})".format(result.TYPES),
+    default="CODES_OVERVIEW",
+    choices=result.TYPES,
+)
 parser.add_argument(
-        "-s", "--style",
-        metavar="STYLE",
-        help="specify print style (choose from {})".format(STYLES),
-        default="yaml",
-        choices=STYLES
-        )
+    "-s",
+    "--style",
+    metavar="STYLE",
+    help="specify print style (choose from {})".format(STYLES),
+    default="yaml",
+    choices=STYLES,
+)
 parser.add_argument(
-        "-t", "--client-refresh-time",
-        metavar="SECONDS",
-        type=int,
-        help="specify refresh time for client printing queue fill level (default: 2)",
-        default="2",
-        )
+    "-t",
+    "--client-refresh-time",
+    metavar="SECONDS",
+    type=int,
+    help="specify refresh time for client printing queue fill level (default: 2)",
+    default="2",
+)
 parser.add_argument(
-        "--silent", action='store_const', const=True, default=False, help='turn off all outpot but the result (default: False)')
+    "--silent",
+    action="store_const",
+    const=True,
+    default=False,
+    help="turn off all outpot but the result (default: False)",
+)
 
 subparsers = parser.add_subparsers(
-        title="endpoint",
-        metavar="ENDPOINT",
-        help=''
-        "The endpoint to call. For endpoint-specific help, use: `ENDPOINT -h'")
+    title="endpoint",
+    metavar="ENDPOINT",
+    help="" "The endpoint to call. For endpoint-specific help, use: `ENDPOINT -h'",
+)
 
 # Build endpoint parsers
 for name in sorted(endpoints.keys()):
     endpoint = endpoints[name]
-    endpoint_parser = subparsers.add_parser(name, help=f"{endpoint.description} ({endpoint.type}).")
+    endpoint_parser = subparsers.add_parser(
+        name, help=f"{endpoint.description} ({endpoint.type})."
+    )
     if endpoint.values:
         for v, t in endpoint.values.items():
             # argparse can't handle dicts, lists and listsoflists like we want...
@@ -102,32 +110,74 @@ for name in sorted(endpoints.keys()):
 # Add coco internal endpoints to argparse here:
 
 # blacklist
-blacklist_parser = subparsers.add_parser("blacklist", help=f"Show the node blacklist (GET).")
-blacklist_parser.set_defaults(func=Endpoint.client_send_request, type="GET", endpoint="blacklist", data={})
-update_blacklist_parser = subparsers.add_parser("update-blacklist", help=f"Update the node blacklist (POST).")
+blacklist_parser = subparsers.add_parser(
+    "blacklist", help=f"Show the node blacklist (GET)."
+)
+blacklist_parser.set_defaults(
+    func=Endpoint.client_send_request, type="GET", endpoint="blacklist", data={}
+)
+update_blacklist_parser = subparsers.add_parser(
+    "update-blacklist", help=f"Update the node blacklist (POST)."
+)
 UPDATE_BLACKLIST_COMMANDS = ["add", "remove", "clear"]
-update_blacklist_parser.add_argument("command", metavar="COMMAND", choices=UPDATE_BLACKLIST_COMMANDS, help=f"Choose from {UPDATE_BLACKLIST_COMMANDS}.")
-update_blacklist_parser.add_argument("--hosts", metavar="HOSTS", type=str, help="Hosts to add or remove.", required=False)
-update_blacklist_parser.set_defaults(func=Endpoint.client_send_request, type="POST", endpoint="update-blacklist", data={}, hosts='[]')
+update_blacklist_parser.add_argument(
+    "command",
+    metavar="COMMAND",
+    choices=UPDATE_BLACKLIST_COMMANDS,
+    help=f"Choose from {UPDATE_BLACKLIST_COMMANDS}.",
+)
+update_blacklist_parser.add_argument(
+    "--hosts", metavar="HOSTS", type=str, help="Hosts to add or remove.", required=False
+)
+update_blacklist_parser.set_defaults(
+    func=Endpoint.client_send_request,
+    type="POST",
+    endpoint="update-blacklist",
+    data={},
+    hosts="[]",
+)
 
 # reset-state
-reset_parser = subparsers.add_parser("reset-state", help=f"Clear the internal state and re-load yaml files (POST).")
-reset_parser.set_defaults(func=Endpoint.client_send_request, type="POST", endpoint="reset-state", data={})
+reset_parser = subparsers.add_parser(
+    "reset-state", help=f"Clear the internal state and re-load yaml files (POST)."
+)
+reset_parser.set_defaults(
+    func=Endpoint.client_send_request, type="POST", endpoint="reset-state", data={}
+)
 
 # saved-states
-saved_states_parser = subparsers.add_parser("saved-states", help=f"Get a list of all previously saved states (GET).")
-saved_states_parser.set_defaults(func=Endpoint.client_send_request, type="GET", endpoint="saved-states", data={})
+saved_states_parser = subparsers.add_parser(
+    "saved-states", help=f"Get a list of all previously saved states (GET)."
+)
+saved_states_parser.set_defaults(
+    func=Endpoint.client_send_request, type="GET", endpoint="saved-states", data={}
+)
 
 # save-state
-save_state_parser = subparsers.add_parser("save-state", help=f"Save the active state for later (POST).")
-save_state_parser.set_defaults(func=Endpoint.client_send_request, type="POST", endpoint="save-state", data={})
-save_state_parser.add_argument("name", metavar="NAME", help=f"Choose a name for the saved state.")
+save_state_parser = subparsers.add_parser(
+    "save-state", help=f"Save the active state for later (POST)."
+)
+save_state_parser.set_defaults(
+    func=Endpoint.client_send_request, type="POST", endpoint="save-state", data={}
+)
 save_state_parser.add_argument(
-        "--overwrite", action='store_const', const=True, default=False, help="Overwrite saved state if it already exists (default: False).")
+    "name", metavar="NAME", help=f"Choose a name for the saved state."
+)
+save_state_parser.add_argument(
+    "--overwrite",
+    action="store_const",
+    const=True,
+    default=False,
+    help="Overwrite saved state if it already exists (default: False).",
+)
 
 # load-state
-load_state_parser = subparsers.add_parser("load-state", help=f"Load a previously saved state (POST).")
-load_state_parser.set_defaults(func=Endpoint.client_send_request, type="POST", endpoint="load-state", data={})
+load_state_parser = subparsers.add_parser(
+    "load-state", help=f"Load a previously saved state (POST)."
+)
+load_state_parser.set_defaults(
+    func=Endpoint.client_send_request, type="POST", endpoint="load-state", data={}
+)
 load_state_parser.add_argument("name", metavar="NAME", help=f"Name of the saved state.")
 
 parsed_args = parser.parse_args()
@@ -147,14 +197,23 @@ if hasattr(parsed_args, "func"):
     if parsed_args.endpoint == "save-state":
         parsed_args.data["overwrite"] = parsed_args.overwrite
         del parsed_args.overwrite
-    result = parsed_args.func(coco_config["host"], coco_config["port"], coco_config["metrics_port"], parsed_args)
+    result = parsed_args.func(
+        coco_config["host"],
+        coco_config["port"],
+        coco_config["metrics_port"],
+        parsed_args,
+    )
     if result:
         if parsed_args.style == "json":
             print(json.dumps(result, indent=2))
         elif parsed_args.style == "yaml":
             print(yaml.dump(result))
         else:
-            print("Unknown print style: {} (Choose from {})".format(parsed_args.style, STYLES))
+            print(
+                "Unknown print style: {} (Choose from {})".format(
+                    parsed_args.style, STYLES
+                )
+            )
     if not parsed_args.silent:
         print("Done.")
 else:

--- a/scripts/coco
+++ b/scripts/coco
@@ -114,6 +114,22 @@ update_blacklist_parser.set_defaults(func=Endpoint.client_send_request, type="PO
 reset_parser = subparsers.add_parser("reset-state", help=f"Clear the internal state and re-load yaml files (POST).")
 reset_parser.set_defaults(func=Endpoint.client_send_request, type="POST", endpoint="reset-state", data={})
 
+# saved-states
+saved_states_parser = subparsers.add_parser("saved-states", help=f"Get a list of all previously saved states (GET).")
+saved_states_parser.set_defaults(func=Endpoint.client_send_request, type="GET", endpoint="saved-states", data={})
+
+# save-state
+save_state_parser = subparsers.add_parser("save-state", help=f"Save the active state for later (POST).")
+save_state_parser.set_defaults(func=Endpoint.client_send_request, type="POST", endpoint="save-state", data={})
+save_state_parser.add_argument("name", metavar="NAME", help=f"Choose a name for the saved state.")
+save_state_parser.add_argument(
+        "--overwrite", action='store_const', const=True, default=False, help="Overwrite saved state if it already exists (default: False).")
+
+# load-state
+load_state_parser = subparsers.add_parser("load-state", help=f"Load a previously saved state (POST).")
+load_state_parser.set_defaults(func=Endpoint.client_send_request, type="POST", endpoint="load-state", data={})
+load_state_parser.add_argument("name", metavar="NAME", help=f"Name of the saved state.")
+
 parsed_args = parser.parse_args()
 
 if hasattr(parsed_args, "func"):
@@ -125,6 +141,12 @@ if hasattr(parsed_args, "func"):
                 print("Unable to parse list of hosts.")
                 exit(1)
         parsed_args.data["command"] = parsed_args.command
+    if parsed_args.endpoint == "load-state" or parsed_args.endpoint == "save-state":
+        parsed_args.data["name"] = parsed_args.name
+        del parsed_args.name
+    if parsed_args.endpoint == "save-state":
+        parsed_args.data["overwrite"] = parsed_args.overwrite
+        del parsed_args.overwrite
     result = parsed_args.func(coco_config["host"], coco_config["port"], coco_config["metrics_port"], parsed_args)
     if result:
         if parsed_args.style == "json":

--- a/scripts/coco
+++ b/scripts/coco
@@ -104,7 +104,7 @@ for name in sorted(endpoints.keys()):
 # blacklist
 blacklist_parser = subparsers.add_parser("blacklist", help=f"Show the node blacklist (GET).")
 blacklist_parser.set_defaults(func=Endpoint.client_send_request, type="GET", endpoint="blacklist", data={})
-update_blacklist_parser = subparsers.add_parser("update-blacklist", help=f"Show the node blacklist (POST).")
+update_blacklist_parser = subparsers.add_parser("update-blacklist", help=f"Update the node blacklist (POST).")
 UPDATE_BLACKLIST_COMMANDS = ["add", "remove", "clear"]
 update_blacklist_parser.add_argument("command", metavar="COMMAND", choices=UPDATE_BLACKLIST_COMMANDS, help=f"Choose from {UPDATE_BLACKLIST_COMMANDS}.")
 update_blacklist_parser.add_argument("--hosts", metavar="HOSTS", type=str, help="Hosts to add or remove.", required=False)

--- a/scripts/cocod
+++ b/scripts/cocod
@@ -6,9 +6,11 @@ import sys
 
 from coco import Master
 
+
 def start(args):
     # Pass all members of the args namespace to the constructor of coco.Master
     master = Master(**vars(args))
+
 
 # The default coco.conf path.
 # The default here should be suitable for running cocod
@@ -18,25 +20,30 @@ def start(args):
 coco_conf = os.path.normpath(os.path.join(sys.path[0], "../conf/coco.conf"))
 
 parser = argparse.ArgumentParser(
-        description="This is the coco (Config Control) server.",
-        epilog="""\
+    description="This is the coco (Config Control) server.",
+    epilog="""\
 If no configuration file is specified via -c, cocod will use {0} which should be suitable for
 running cocod without first installing it.
-""".format(coco_conf)
-        )
+""".format(
+        coco_conf
+    ),
+)
 
 # Global options
 parser.add_argument(
-        "-c", "--conf",
-        metavar="PATH",
-        help="read coco.conf file specified by PATH",
-        default=coco_conf
-        )
+    "-c",
+    "--conf",
+    metavar="PATH",
+    help="read coco.conf file specified by PATH",
+    default=coco_conf,
+)
 parser.add_argument(
-        "--reset",
-        help="reset the internal state on start",
-        action='store_const', const=True, default=False
-        )
+    "--reset",
+    help="reset the internal state on start",
+    action="store_const",
+    const=True,
+    default=False,
+)
 
 parsed_args = parser.parse_args()
 

--- a/tests/test_call_coco.py
+++ b/tests/test_call_coco.py
@@ -45,7 +45,7 @@ def runner(farm):
 def test_forward(farm, runner):
     """Test if a request gets forwarded to another coco endpoint."""
     request = {"foo": 0, "bar": "1337"}
-    response = runner.client(ENDPT_NAME, request)
+    response = runner.client(ENDPT_NAME, ["0", "1337"])
 
     for p in farm.ports:
         assert farm.counters()[p][ENDPT_NAME] == 1
@@ -73,7 +73,7 @@ def test_forward(farm, runner):
         assert response[ENDPT_NAME3][ENDPT_NAME3][h]["reply"] == request
 
     for i in range(N_CALLS):
-        runner.client(ENDPT_NAME, request)
+        runner.client(ENDPT_NAME, ["0", "1337"])
     for p in farm.ports:
         assert farm.counters()[p][ENDPT_NAME] == N_CALLS + 1
         assert farm.counters()[p][ENDPT_NAME2] == N_CALLS + 1

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -91,8 +91,7 @@ def runner(farm):
 def test_forward(farm, runner):
     """Test coco's forward reply check."""
     # Test failed type check
-    request = {"ok": 1}
-    response = runner.client("type_check_fail", request)
+    response = runner.client("type_check_fail", ["1"])
     for p in farm.ports:
         assert farm.counters()[p]["pong"] == 1
 
@@ -104,8 +103,7 @@ def test_forward(farm, runner):
     assert reply["type"] == ["ok"]
 
     # Test passing type check
-    request = {"ok": False}
-    response = runner.client("type_check", request)
+    response = runner.client("type_check", ["False"])
     for p in farm.ports:
         assert farm.counters()[p]["pong"] == 2
 
@@ -114,14 +112,12 @@ def test_forward(farm, runner):
     assert "failed_checks" not in response
 
     # Test failed value check
-    request = {"ok": False}
-    response = runner.client("value_check", request)
+    response = runner.client("value_check", ["False"])
     for p in farm.ports:
         assert farm.counters()[p]["pong"] == 3
     assert response["success"] is False
 
-    request = {"ok": False}
-    response = runner.client("value_check", request)
+    response = runner.client("value_check", ["False"])
     for p in farm.ports:
         assert farm.counters()[p]["pong"] == 4
 
@@ -133,8 +129,7 @@ def test_forward(farm, runner):
     assert reply["value"] == ["ok"]
 
     # Test passing value check
-    request = {"ok": True}
-    response = runner.client("value_check", request)
+    response = runner.client("value_check", ["True"])
     for p in farm.ports:
         assert farm.counters()[p]["pong"] == 5
 
@@ -143,8 +138,7 @@ def test_forward(farm, runner):
     assert "failed_checks" not in response
 
     # Test failed identical check
-    request = {"rand": True}
-    response = runner.client("identical_check", request)
+    response = runner.client("identical_check", ["True"])
     for p in farm.ports:
         assert farm.counters()[p]["rand"] == 1
 
@@ -156,8 +150,7 @@ def test_forward(farm, runner):
     assert reply["not_identical"] == ["all"]
 
     # Test passing identical check
-    request = {"rand": False}
-    response = runner.client("identical_check", request)
+    response = runner.client("identical_check", ["False"])
     for p in farm.ports:
         assert farm.counters()[p]["rand"] == 2
 
@@ -166,8 +159,7 @@ def test_forward(farm, runner):
     assert "failed_checks" not in response
 
     # Test failed check on before
-    request = {"ok": True}
-    response = runner.client("bvalue_check", request)
+    response = runner.client("bvalue_check", ["True"])
     for p in farm.ports:
         assert farm.counters()[p]["pong"] == 6
 
@@ -179,8 +171,7 @@ def test_forward(farm, runner):
     assert reply["missing"] == ["ok"]
 
     # Test failed check on after
-    request = {"ok": True}
-    response = runner.client("avalue_check", request)
+    response = runner.client("avalue_check", ["True"])
     for p in farm.ports:
         assert farm.counters()[p]["pong"] == 7
 

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -37,7 +37,7 @@ def runner(farm):
 def test_forward(farm, runner):
     """Test if a request gets forwarded to an external endpoint."""
     request = {"foo": 0, "bar": "1337"}
-    response = runner.client(ENDPT_NAME, request)
+    response = runner.client(ENDPT_NAME, ["0", "1337"])
 
     for p in farm.ports:
         assert farm.counters()[p][ENDPT_NAME] == 1
@@ -51,7 +51,7 @@ def test_forward(farm, runner):
         assert response[ENDPT_NAME][h]["reply"] == request
 
     for i in range(N_CALLS):
-        runner.client(ENDPT_NAME, request)
+        runner.client(ENDPT_NAME, ["0", "1337"])
     for p in farm.ports:
         assert farm.counters()[p][ENDPT_NAME] == N_CALLS + 1
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -45,9 +45,8 @@ def runner(farm):
 
 def test_metrics(farm, runner):
     """Test metrics are counting endpoint calls."""
-    request = {"foo": 0, "bar": "1337"}
     for i in range(N_CALLS):
-        response = runner.client(ENDPT_NAME, request)
+        runner.client(ENDPT_NAME, ["0", "1337"])
 
     # Get metrics
     metrics = requests.get(f"http://localhost:{PORT}/metrics")
@@ -69,7 +68,7 @@ def test_metrics(farm, runner):
 
     # Only expect one endpoint call
     assert (
-        len(count_coco) == 5
+        len(count_coco) == 8
     )  # 1, plus two from internal metrics. Needs to be kept up to date
     count_coco = count_coco[0]
     assert list(count_coco.labels.keys()) == ["endpoint"]

--- a/tests/test_on_failure.py
+++ b/tests/test_on_failure.py
@@ -75,7 +75,7 @@ def test_on_reply(farm, runner):
     request = {}
 
     # Test call on failure
-    response = runner.client("call_all", request)
+    response = runner.client("call_all")
     for p in farm.ports:
         assert farm.counters()[p]["status"] == 1
         assert farm.counters()[p]["restart"] == 1
@@ -90,7 +90,7 @@ def test_on_reply(farm, runner):
     STATUS_FAILER.count = 0
 
     # Test call_single_host
-    response = runner.client("call_single", request)
+    response = runner.client("call_single")
 
     # Check failure report
     failed_host = list(response["failed_checks"]["status"].keys())

--- a/tests/test_save_to_state.py
+++ b/tests/test_save_to_state.py
@@ -49,7 +49,7 @@ def test_save_state(runner):
     assert response["state"][STATE_PATH]["2"] == {}
 
     # Set state to INT_VAL
-    runner.client(SAVE_ENDPT_NAME, {INT_VAL_NAME: INT_VAL})
+    runner.client(SAVE_ENDPT_NAME, [str(INT_VAL)])
     response = runner.client(GET_ENDPT_NAME1)
     assert "state" in response
     assert STATE_PATH in response["state"]

--- a/tests/test_saved_states.py
+++ b/tests/test_saved_states.py
@@ -1,0 +1,104 @@
+"""Test saving and loading states."""
+
+import json
+import pathlib
+import pytest
+import tempfile
+
+from coco.test import coco_runner
+
+SAVE_ENDPT_NAME = "save"
+SAVE_EXCLUDED_ENDPT_NAME = "save_excluded"
+
+state_dir = tempfile.TemporaryDirectory()
+active_state = pathlib.Path(state_dir.name, "active")
+saved_state = pathlib.Path(state_dir.name, "backup")
+
+INT_VAL = 5
+INT_VAL_NAME = "val"
+STATE_PATH = "test_state"
+EXCLUDED_PATH = "excluded"
+
+CONFIG = {
+    "log_level": "INFO",
+    "storage_path": state_dir.name,
+    "exclude_from_reset": [EXCLUDED_PATH],
+    "groups": {"no_group": ["no_host", "doesnt_exist"]},
+}
+
+ENDPOINTS = {
+    SAVE_ENDPT_NAME: {
+        "call": {"forward": None},
+        "save_state": [STATE_PATH + "/1", STATE_PATH + "/2"],
+        "values": {INT_VAL_NAME: "int"},
+    },
+    SAVE_EXCLUDED_ENDPT_NAME: {
+        "call": {"forward": None},
+        "save_state": [EXCLUDED_PATH],
+        "values": {INT_VAL_NAME: "int"},
+    },
+}
+
+
+@pytest.fixture
+def runner():
+    return coco_runner.Runner(CONFIG, ENDPOINTS)
+
+
+def test_save_state(runner):
+    """Test saving the state."""
+    assert saved_state.exists() is False
+
+    # Save the state, check it exists and is identical to the active state.
+    runner.client("save-state", ["backup"])
+    assert saved_state.exists()
+    with open(saved_state, "r") as saved, open(active_state, "r") as active:
+        assert json.load(saved) == json.load(active)
+
+    # change the active state and check that now it differs from the backup
+    runner.client(SAVE_ENDPT_NAME, [str(INT_VAL)])
+    with open(saved_state, "r") as saved, open(active_state, "r") as active:
+        assert json.load(saved) != json.load(active)
+
+    # load the backup as the active state again
+    runner.client("load-state", ["backup"])
+    with open(saved_state, "r") as saved, open(active_state, "r") as active:
+        assert json.load(saved) == json.load(active)
+
+    # Alter the excluded part of the active config. This difference should survive a load-state.
+    runner.client(SAVE_EXCLUDED_ENDPT_NAME, [str(INT_VAL)])
+    runner.client("load-state", ["backup"])
+    with open(saved_state, "r") as saved, open(active_state, "r") as active:
+        assert json.load(saved) != json.load(active)
+
+    # try overwriting without and with setting overwrite=True
+    result = runner.client("save-state", ["backup"])
+    assert result["status_code"] == 400
+    with open(saved_state, "r") as saved, open(active_state, "r") as active:
+        assert json.load(saved) != json.load(active)
+
+    result = runner.client("save-state", ["--overwrite", "backup"])
+    assert result["success"] == True
+    with open(saved_state, "r") as saved, open(active_state, "r") as active:
+        assert json.load(saved) == json.load(active)
+
+    # test the saved-states endpoint
+    get_states = runner.client("saved-states")
+    assert get_states["saved-states"]["http://coco/"]["reply"] == ["backup"]
+
+    # add one more saved state and test again
+    runner.client("save-state", ["blubb"])
+    get_states = runner.client("saved-states")
+    assert get_states["saved-states"]["http://coco/"]["reply"] == ["backup", "blubb"]
+
+    # Try to save into active state
+    result = runner.client("save-state", ["active"])
+    assert result["status_code"] == 400
+
+    # Try to load active state
+    result = runner.client("load-state", ["active"])
+    assert result["status_code"] == 400
+
+    # Try to load state that doesn't exist
+    result = runner.client("load-state", ["argh"])
+    assert result["status_code"] == 400

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -78,7 +78,7 @@ def runner(farm):
     STATEFILE.flush()
     CONFIG["load_state"] = {STATE_PATH.split("/")[0]: STATEFILE.name}
     print(STATEFILE.name)
-    return coco_runner.Runner(CONFIG, ENDPOINTS)
+    return coco_runner.Runner(CONFIG, ENDPOINTS, reset_on_start=True)
 
 
 def test_sched(farm, runner):

--- a/tests/test_set_state.py
+++ b/tests/test_set_state.py
@@ -116,20 +116,18 @@ def test_get_state(runner):
     assert response["state"][STATE_PATH] == 5
 
     # Test passing check against state hash
-    runner.client(CHECK_HASH_ENDPT_NAME, {"data": State.hash_dict({"test_state": 5})})
+    runner.client(CHECK_HASH_ENDPT_NAME, [str(State.hash_dict({"test_state": 5}))])
     assert "failed_checks" not in response
 
     # Test failing check against state hash
-    response = runner.client(
-        CHECK_HASH_ENDPT_NAME, {"data": State.hash_dict({"foo": 5})}
-    )
+    response = runner.client(CHECK_HASH_ENDPT_NAME, [str(State.hash_dict({"foo": 5}))])
     assert "failed_checks" in response
     assert HASH_ENDPT_NAME in response["failed_checks"]
     for r in response["failed_checks"][HASH_ENDPT_NAME].values():
         assert r == {"reply": {"mismatch_with_state_hash": ["data"]}}
 
     response = runner.client(
-        CHECK_HASH_ENDPT_NAME, {"data": State.hash_dict({"test_state": 4})}
+        CHECK_HASH_ENDPT_NAME, [str(State.hash_dict({"test_state": 4}))]
     )
     assert "failed_checks" in response
     assert HASH_ENDPT_NAME in response["failed_checks"]
@@ -140,13 +138,13 @@ def test_get_state(runner):
     runner.client(SET_ENDPT_NAME_DICT)
     # Test passing check against partly state hash
     response = runner.client(
-        CHECK_HASH_ENDPT_NAME2, {"data": State.hash_dict({"a": "fu"})}
+        CHECK_HASH_ENDPT_NAME2, [str(State.hash_dict({"a": "fu"}))]
     )
     assert "failed_checks" not in response
 
     # Test failing check against partly state hash
     response = runner.client(
-        CHECK_HASH_ENDPT_NAME2, {"data": State.hash_dict({"a": "foo"})}
+        CHECK_HASH_ENDPT_NAME2, [str(State.hash_dict({"a": "foo"}))]
     )
     assert "failed_checks" in response
     assert HASH_ENDPT_NAME in response["failed_checks"]
@@ -155,37 +153,37 @@ def test_get_state(runner):
 
     # Test checks against state
     # Test passing check against part of state
-    response = runner.client(CHECK_STATE_ENDPT_NAME, {"data": "fu"})
+    response = runner.client(CHECK_STATE_ENDPT_NAME, ["fu"])
     assert "failed_checks" not in response
 
     # Test failing check against part of state
-    response = runner.client(CHECK_STATE_ENDPT_NAME, {"data": "f00"})
+    response = runner.client(CHECK_STATE_ENDPT_NAME, ["f00"])
     assert "failed_checks" in response
     assert HASH_ENDPT_NAME in response["failed_checks"]
     for r in response["failed_checks"][HASH_ENDPT_NAME].values():
         assert r == {"reply": {"mismatch_with_state": ["data"]}}
-    response = runner.client(CHECK_STATE_ENDPT_NAME, {"data": ""})
+    response = runner.client(CHECK_STATE_ENDPT_NAME, [""])
     assert "failed_checks" in response
     assert HASH_ENDPT_NAME in response["failed_checks"]
     for r in response["failed_checks"][HASH_ENDPT_NAME].values():
         assert r == {"reply": {"mismatch_with_state": ["data"]}}
 
     # Test passing check against state
-    response = runner.client(CHECK_STATE_ENDPT_NAME2, {"n": '{"a": "fu"}'})
+    response = runner.client(CHECK_STATE_ENDPT_NAME2, ['{"a": "fu"}'])
     assert "failed_checks" not in response
 
     # Test failing check against state
-    response = runner.client(CHECK_STATE_ENDPT_NAME2, {"n": '{"n": {"a": 0}}'})
+    response = runner.client(CHECK_STATE_ENDPT_NAME2, ['{"n": {"a": 0}}'])
     assert "failed_checks" in response
     assert HASH_ENDPT_NAME in response["failed_checks"]
     for r in response["failed_checks"][HASH_ENDPT_NAME].values():
         assert r == {"reply": {"mismatch_with_state": ["all"]}}
-    response = runner.client(CHECK_STATE_ENDPT_NAME2, {"n": '{"aa": "fu"}'})
+    response = runner.client(CHECK_STATE_ENDPT_NAME2, ['{"aa": "fu"}'])
     assert "failed_checks" in response
     assert HASH_ENDPT_NAME in response["failed_checks"]
     for r in response["failed_checks"][HASH_ENDPT_NAME].values():
         assert r == {"reply": {"mismatch_with_state": ["all"]}}
-    response = runner.client(CHECK_STATE_ENDPT_NAME2, {"n": "{}"})
+    response = runner.client(CHECK_STATE_ENDPT_NAME2, ["{}"])
     assert "failed_checks" in response
     assert HASH_ENDPT_NAME in response["failed_checks"]
     for r in response["failed_checks"][HASH_ENDPT_NAME].values():

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,36 @@
+from coco import state
+
+from copy import deepcopy
+import tempfile
+
+
+def test_exclude():
+    state_path = tempfile.TemporaryDirectory()
+    test_state = state.State(
+        "DEBUG",
+        state_path.name,
+        default_state_files={},
+        exclude_from_reset=["foo", "bar/foo"],
+    )
+
+    dict_ = {"foo": 1, "bar": 0}
+    print("testing bar and {}".format(dict_))
+    ex = deepcopy(dict_)
+    test_state._exclude_paths("bar", ex)
+    assert ex == {"bar": 0}
+
+    print("testing '' and {}".format(dict_))
+    test_state._exclude_paths("", ex)
+    assert ex == {"bar": 0}
+
+    dict_ = {"bar": {"foo": 0}, "foo": 1, "fubar": 1}
+    ex = deepcopy(dict_)
+    print("testing bar and {}".format(dict_))
+    test_state._exclude_paths("bar", ex)
+    assert ex == {"bar": {"foo": 0}, "fubar": 1}
+
+    dict_ = {"bar": {"foo": 0}, "foo": 1, "fubar": 1}
+    ex = deepcopy(dict_)
+    print("testing '' and {}".format(dict_))
+    test_state._exclude_paths("", ex)
+    assert ex == {"bar": {}, "fubar": 1}

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -37,8 +37,7 @@ def runner(farm):
 
 def test_timeout_1s(farm, runner):
     """Test if a request gets forwarded to an external endpoint."""
-    request = {"foo": 0, "bar": "1337"}
-    response = runner.client(ENDPT_NAME, request)
+    response = runner.client(ENDPT_NAME, ["0", "1337"])
 
     for p in farm.ports:
         assert farm.counters()[p][ENDPT_NAME] == 1

--- a/tests/test_wait.py
+++ b/tests/test_wait.py
@@ -50,7 +50,7 @@ def test_forward(farm, runner):
     """Test if a request gets forwarded to an external endpoint."""
     request = {"foo": 0, "bar": "1337"}
     t0 = time.time()
-    response = runner.client(ENDPT_NAME, request)
+    response = runner.client(ENDPT_NAME, ["0", "1337"])
     t1 = time.time()
     assert t1 - t0 > T_WAIT
     assert t1 - t0 < T_WAIT + T_HOW_SLOW_IS_COCO
@@ -68,7 +68,7 @@ def test_forward(farm, runner):
 
 
 def test_timestamp(farm, runner):
-    response = runner.client(TS_ENDPT_NAME, {})
+    response = runner.client(TS_ENDPT_NAME)
     for p in farm.ports:
         assert farm.counters()[p][TS_ENDPT_NAME] == 1
     assert TS_ENDPT_NAME in response
@@ -79,7 +79,7 @@ def test_timestamp(farm, runner):
 
         assert response[TS_ENDPT_NAME][h]["status"] == 200
 
-    response = runner.client(GET_TS_ENDPT_NAME, {})
+    response = runner.client(GET_TS_ENDPT_NAME)
     for p in farm.ports:
         assert farm.counters()[p][GET_TS_ENDPT_NAME] == 1
     assert GET_TS_ENDPT_NAME in response


### PR DESCRIPTION
With this, cocos state can be written to disk using
```
coco save-state foo
```
and later restored again with
```
coco load-state foo
```

See all saved states with

```
coco saved-states
```


BREAKING CHANGE: the state path in the config is not a file but a directory now. Move the state in the coco installation from `/old/location` to `/old/location/active` (or replace it with an empty directory).

Closes #192 