### PR TITLE
handle redis server timing out

### DIFF
--- a/coco/worker.py
+++ b/coco/worker.py
@@ -165,8 +165,21 @@ def main_loop(
 
             # Always attempt to return the result so that the client doesn't hang...
             finally:
-                await conn.execute("rpush", f"{name}:res", json.dumps(result))
-                await conn.execute("rpush", f"{name}:code", code)
+                while True:
+                    try:
+                        await conn.execute("rpush", f"{name}:res", json.dumps(result))
+                    except aioredis.errors.ConnectionClosedError as err:
+                        logger.info("Redis connection closed while processing /{endpoint_name}. Opening new connection...")
+                        try:
+                            conn = await aioredis.create_connection(("localhost", 6379), encoding="utf-8")
+                        except ConnectionError as e:
+                            logger.error(
+                                f"coco.worker: failure connecting to redis. Make sure it is running: {e}"
+                            )
+                            exit(1)
+                    else:
+                        break
+                    await conn.execute("rpush", f"{name}:code", code)
 
         # optionally close connection
         conn.close()

--- a/coco/worker.py
+++ b/coco/worker.py
@@ -169,9 +169,13 @@ def main_loop(
                     try:
                         await conn.execute("rpush", f"{name}:res", json.dumps(result))
                     except aioredis.errors.ConnectionClosedError as err:
-                        logger.info("Redis connection closed while processing /{endpoint_name}. Opening new connection...")
+                        logger.info(
+                            f"Redis connection closed while processing /{endpoint_name}. Opening new connection..."
+                        )
                         try:
-                            conn = await aioredis.create_connection(("localhost", 6379), encoding="utf-8")
+                            conn = await aioredis.create_connection(
+                                ("localhost", 6379), encoding="utf-8"
+                            )
                         except ConnectionError as e:
                             logger.error(
                                 f"coco.worker: failure connecting to redis. Make sure it is running: {e}"

--- a/coco/worker.py
+++ b/coco/worker.py
@@ -40,6 +40,16 @@ def signal_handler(sig, frame):
 signal.signal(signal.SIGINT, signal_handler)
 
 
+async def _open_redis_connection():
+    try:
+        return await aioredis.create_connection(("localhost", 6379), encoding="utf-8")
+    except ConnectionError as e:
+        logger.error(
+            f"coco.worker: failure connecting to redis. Make sure it is running: {e}"
+        )
+        exit(1)
+
+
 def main_loop(
     endpoints, forwarder, coco_port, metrics_port, log_level, frontend_timeout
 ):
@@ -62,15 +72,7 @@ def main_loop(
         forwarder.start_prometheus_server(metrics_port)
         forwarder.init_metrics()
 
-        try:
-            conn = await aioredis.create_connection(
-                ("localhost", 6379), encoding="utf-8"
-            )
-        except ConnectionError as e:
-            logger.error(
-                f"coco.worker: failure connecting to redis. Make sure it is running: {e}"
-            )
-            exit(1)
+        conn = await _open_redis_connection()
 
         while True:
             # Wait until the name of an endpoint call is in the queue.
@@ -165,24 +167,18 @@ def main_loop(
 
             # Always attempt to return the result so that the client doesn't hang...
             finally:
-                while True:
-                    try:
-                        await conn.execute("rpush", f"{name}:res", json.dumps(result))
-                    except aioredis.errors.ConnectionClosedError as err:
-                        logger.info(
-                            f"Redis connection closed while processing /{endpoint_name}. Opening new connection..."
-                        )
-                        try:
-                            conn = await aioredis.create_connection(
-                                ("localhost", 6379), encoding="utf-8"
-                            )
-                        except ConnectionError as e:
-                            logger.error(
-                                f"coco.worker: failure connecting to redis. Make sure it is running: {e}"
-                            )
-                            exit(1)
-                    else:
-                        break
+                # If processing this request took a long time, the redis server may have hung up..
+                try:
+                    await conn.execute("rpush", f"{name}:res", json.dumps(result))
+                except aioredis.errors.ConnectionClosedError as err:
+                    logger.info(
+                        f"Redis connection closed while processing /{endpoint_name}. Opening new connection..."
+                    )
+
+                    # open new connection and try one more time
+                    conn = await _open_redis_connection()
+                    await conn.execute("rpush", f"{name}:res", json.dumps(result))
+                finally:
                     await conn.execute("rpush", f"{name}:code", code)
 
         # optionally close connection


### PR DESCRIPTION
```
May 29 14:15:08 csBfs cocod[28733]: [2020-05-29 14:15:08 -0700] [28736] [DEBUG] [coco.worker] coco.worker: Calling /crash: {'coco_report_type': 'CODES_OVERVIEW'}
May 29 14:15:08 csBfs cocod[28733]: [2020-05-29 14:15:08 -0700] [28736] [INFO] [coco.endpoint.crash] endpoint called
May 29 14:15:08 csBfs cocod[28733]: [2020-05-29 14:15:08 -0700] [28736] [DEBUG] [coco.endpoint.crash] Request "None"
May 29 14:20:08 csBfs cocod[28733]: Connection <RedisConnection [db:0]> has pending commands, closing it.
May 29 14:21:11 csBfs cocod[28733]: [2020-05-29 14:21:11 -0700] [28736] [DEBUG] [coco.endpoint.crash] Success!
May 29 14:21:11 csBfs cocod[28733]: [2020-05-29 14:21:11 -0700] [28736] [INFO] [coco.worker] Redis connection closed while processing /{endpoint_name}. Opening new connection...
```

Closes #203