### PR TITLE
Speed up reply<->state check

### DIFF
--- a/coco/check.py
+++ b/coco/check.py
@@ -99,6 +99,7 @@ class Check:
         """
         if not self.save_to_state:
             return
+        logger.debug(f"Saving reply {reply} to state {self.save_to_state}.")
         merged = dict()
         for r in reply.values():
             if isinstance(r, dict):

--- a/coco/check.py
+++ b/coco/check.py
@@ -377,23 +377,16 @@ class StateReplyCheck(ReplyCheck):
             if r:
                 reply.update(r)
 
-        for host, result_ in reply.items():
-            if not result_:
-                if self.state_paths:
+        if self.state_paths:
+            for host, result_ in reply.items():
+                if not result_:
                     for name in self.state_paths.keys():
                         logger.debug(
                             f"/{self._name}: Missing value '{name}' in reply from {host}."
                         )
                         failed_hosts.add(host)
                         result.report_failure(self._name, host, "missing", name)
-                if self.state_path:
-                    logger.debug(
-                        f"/{self._name}: Empty reply to /{self.name} from {host}."
-                    )
-                    failed_hosts.add(host)
-                    result.report_failure(self._name, host, "missing", "all")
-                continue
-            if self.state_paths:
+                    continue
                 for name, value in result_.items():
                     if name not in self.state_paths:
                         logger.debug(
@@ -417,8 +410,17 @@ class StateReplyCheck(ReplyCheck):
                         )
                         failed_hosts.add(host)
                         result.report_failure(self._name, host, "missing", name)
-            if self.state_path:
-                state_value = self.state.read(self.state_path)
+
+        if self.state_path:
+            state_value = self.state.read(self.state_path)
+            for host, result_ in reply.items():
+                if not result_:
+                    logger.debug(
+                        f"/{self._name}: Empty reply to /{self.name} from {host}."
+                    )
+                    failed_hosts.add(host)
+                    result.report_failure(self._name, host, "missing", "all")
+                    continue
                 if result_ != state_value:
                     logger.debug(
                         f"/{self._name}: Reply from {host} doesn't match "

--- a/coco/check.py
+++ b/coco/check.py
@@ -328,11 +328,12 @@ class StateReplyCheck(ReplyCheck):
 
     def __init__(self, name, state_paths, on_failure, save_to_state, forwarder, state):
         if isinstance(state_paths, str):
-            if not state.find_or_create(state_paths):
+            if not state.exists(state_paths):
                 logger.debug(
                     f"State path in state-reply-check for /{name} does not exist. "
                     f"Creating it..."
                 )
+                state.write(state_paths, None)
             self.state_path = state_paths
             self.state_paths = None
         elif isinstance(state_paths, dict):
@@ -342,11 +343,12 @@ class StateReplyCheck(ReplyCheck):
                         f"Found value '{field}' of type '{type(path).__name__}' "
                         f"in state-reply-check for /{name} (expected 'str')."
                     )
-                if not state.find_or_create(path):
+                if not state.exists(path):
                     logger.debug(
                         f"State path for field '{field}' in state-reply-check for "
                         f"/{name} does not exist. Creating it..."
                     )
+                    state.write(path, None)
             self.state_path = None
             self.state_paths = state_paths
         else:

--- a/coco/endpoint.py
+++ b/coco/endpoint.py
@@ -292,6 +292,9 @@ class Endpoint:
                     f".conf' is of type '{type(save_to_state).__name__}' "
                     f"(expected str)."
                 )
+            logger.debug(
+                f"Endpoint {self.name} will save replies to state: {save_to_state}."
+            )
 
         on_failure = check_dict.get("on_failure", None)
         if on_failure:

--- a/coco/endpoint.py
+++ b/coco/endpoint.py
@@ -106,10 +106,14 @@ class Endpoint:
 
                 # If save_state is set, the configured values have to match.
                 if self.values:
+
                     # Check if endpoint value types match the associated part of the saved state
                     for key in self.values.keys():
                         try:
-                            if not isinstance(path[key], self.values[key]):
+                            if not (
+                                path[key] is None
+                                or isinstance(path[key], self.values[key])
+                            ):
                                 raise RuntimeError(
                                     f"Value {key} in configured initial state at /{save_state}/ "
                                     f"has type {type(path[key]).__name__} "

--- a/coco/state.py
+++ b/coco/state.py
@@ -224,6 +224,26 @@ class State:
                 if excluded in state:
                     del state[excluded]
 
+    def exists(self, path):
+        """
+        Check if a path exists in the state.
+
+        Parameters
+        ----------
+        path : str
+            A path like "path/to/state/entry" or "/path/to/state/entry".
+
+        Returns
+        -------
+        bool
+            True, if the path exists in the state.
+        """
+        try:
+            self._find(path)
+        except InternalError:
+            return False
+        return True
+
     def _find(self, path):
         """
         Find `"an/entry/by/path"` and return the entry.

--- a/coco/state.py
+++ b/coco/state.py
@@ -256,6 +256,11 @@ class State:
         Returns
         -------
             The state entry.
+
+        Raises
+        ------
+        InternalError
+            If the path doesn't exist.
         """
         if path is None or path == "" or path == "/":
             return self._storage.state

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -4,7 +4,7 @@ import os
 from subprocess import Popen, PIPE
 import yaml
 
-from coco.state import State
+from coco.util import hash_dict
 
 path = os.path.dirname(os.path.abspath(__file__))
 cmd = "{}/hash".format(path)
@@ -21,7 +21,7 @@ def test_simple_hash():
     # remove the \n at the end of the line
     cpphash = cpphash[:-1]
 
-    assert cpphash == State.hash_dict(config)
+    assert cpphash == hash_dict(config)
 
 
 def test_big_config_hash():
@@ -38,4 +38,4 @@ def test_big_config_hash():
     # remove the \n at the end of the line
     cpphash = cpphash[:-1]
 
-    assert cpphash == State.hash_dict(config)
+    assert cpphash == hash_dict(config)

--- a/tests/test_set_state.py
+++ b/tests/test_set_state.py
@@ -2,7 +2,7 @@
 import pytest
 
 from coco.test import coco_runner, endpoint_farm
-from coco.state import State
+from coco.util import hash_dict
 
 SET_ENDPT_NAME = "set"
 SET_ENDPT_NAME_INT = "set_int"
@@ -116,19 +116,17 @@ def test_get_state(runner):
     assert response["state"][STATE_PATH] == 5
 
     # Test passing check against state hash
-    runner.client(CHECK_HASH_ENDPT_NAME, [str(State.hash_dict({"test_state": 5}))])
+    runner.client(CHECK_HASH_ENDPT_NAME, [str(hash_dict({"test_state": 5}))])
     assert "failed_checks" not in response
 
     # Test failing check against state hash
-    response = runner.client(CHECK_HASH_ENDPT_NAME, [str(State.hash_dict({"foo": 5}))])
+    response = runner.client(CHECK_HASH_ENDPT_NAME, [str(hash_dict({"foo": 5}))])
     assert "failed_checks" in response
     assert HASH_ENDPT_NAME in response["failed_checks"]
     for r in response["failed_checks"][HASH_ENDPT_NAME].values():
         assert r == {"reply": {"mismatch_with_state_hash": ["data"]}}
 
-    response = runner.client(
-        CHECK_HASH_ENDPT_NAME, [str(State.hash_dict({"test_state": 4}))]
-    )
+    response = runner.client(CHECK_HASH_ENDPT_NAME, [str(hash_dict({"test_state": 4}))])
     assert "failed_checks" in response
     assert HASH_ENDPT_NAME in response["failed_checks"]
     for r in response["failed_checks"][HASH_ENDPT_NAME].values():
@@ -137,15 +135,11 @@ def test_get_state(runner):
     # The same for a part of the state:
     runner.client(SET_ENDPT_NAME_DICT)
     # Test passing check against partly state hash
-    response = runner.client(
-        CHECK_HASH_ENDPT_NAME2, [str(State.hash_dict({"a": "fu"}))]
-    )
+    response = runner.client(CHECK_HASH_ENDPT_NAME2, [str(hash_dict({"a": "fu"}))])
     assert "failed_checks" not in response
 
     # Test failing check against partly state hash
-    response = runner.client(
-        CHECK_HASH_ENDPT_NAME2, [str(State.hash_dict({"a": "foo"}))]
-    )
+    response = runner.client(CHECK_HASH_ENDPT_NAME2, [str(hash_dict({"a": "foo"}))])
     assert "failed_checks" in response
     assert HASH_ENDPT_NAME in response["failed_checks"]
     for r in response["failed_checks"][HASH_ENDPT_NAME].values():


### PR DESCRIPTION
Speeds up the kotekan config check by minimizing the number of DeepDiff calls.

There's a bit of refactoring and test additions to facilitate the change, but the commit messages hopefully make the review easy.

The two `fix` commits fix an issue discovered when adding the test.

Closes #161 