### PR TITLE
Ael/config endpoint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: [ 3.8 ]
+        python_version: [ 3.8, 3.9, 3.10, 3.11]
     steps:
       - uses: actions/checkout@v2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a base image
-FROM python:3.7-slim
+FROM python:3.8-slim
 
 ## The maintainer name and email
 LABEL maintainer="CHIME/FRB Collaboration"
@@ -7,21 +7,16 @@ LABEL maintainer="CHIME/FRB Collaboration"
 ADD . /coco
 
 RUN apt-get update && \
-    apt-get install -y apt-utils && \
-    apt-get install -y software-properties-common && \
-    apt-get install -y git && \
-    apt-get install -y build-essential && \
-    apt-get install -y libmariadb-dev && \
-    apt-get install -y libevent-dev && \
-    apt-get install -y libhdf5-dev && \
+    apt-get install -y apt-utils software-properties-common git build-essential \
+    libmariadb-dev libevent-dev && \
     pip install flask && \
     pip install -r /coco/requirements.txt && \
-    pip install /coco && \
+    pip install /coco
 
-    #-----------------------
-    # Minimize container size
-    #-----------------------
-    apt-get remove -y curl git && \
+#-----------------------
+# Minimize container size
+#-----------------------
+RUN apt-get remove -y curl git && \
     apt-get autoremove -y && \
     apt-get clean -y && \
     rm -rf /tmp/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ RUN apt-get update && \
 RUN apt-get remove -y curl git && \
     apt-get autoremove -y && \
     apt-get clean -y && \
-    rm -rf /tmp/build
+    rm -rf /tmp/build /coco

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a base image
-FROM python:3.8-slim
+FROM python:3.9-slim
 
 ## The maintainer name and email
 LABEL maintainer="CHIME/FRB Collaboration"
@@ -7,16 +7,16 @@ LABEL maintainer="CHIME/FRB Collaboration"
 ADD . /coco
 
 RUN apt-get update && \
-    apt-get install -y apt-utils software-properties-common git build-essential \
+    apt-get install -y apt-utils software-properties-common git build-essential curl \
     libmariadb-dev libevent-dev && \
-    pip install flask && \
-    pip install -r /coco/requirements.txt && \
-    pip install /coco
+    pip install --use-deprecated=legacy-resolver flask && \
+    pip install --use-deprecated=legacy-resolver -r /coco/requirements.txt && \
+    pip install --use-deprecated=legacy-resolver /coco
 
 #-----------------------
 # Minimize container size
 #-----------------------
-RUN apt-get remove -y curl git && \
+RUN apt-get remove -y git && \
     apt-get autoremove -y && \
     apt-get clean -y && \
     rm -rf /tmp/build /coco

--- a/coco/check.py
+++ b/coco/check.py
@@ -116,7 +116,11 @@ class Check:
         for r in reply.values():
             if isinstance(r, dict):
                 merged.update(r)
-        self.state.write(self.save_to_state, merged)
+        if isinstance(self.save_to_state, str):
+            self.state.write(self.save_to_state, merged)
+        else:
+            for key, targ in self.save_to_state.items():
+                self.state.write(key, merged[targ])
 
 
 class ReplyCheck(Check):

--- a/coco/check.py
+++ b/coco/check.py
@@ -417,6 +417,14 @@ class StateReplyCheck(ReplyCheck):
                         failed_hosts.add(host)
                         result.report_failure(self._name, host, "missing", name)
                     continue
+                if result_ == "Timeout":
+                    for name in self.state_paths.keys():
+                        logger.debug(
+                            f"/{self._name}: Reply timed out for {host}."
+                        )
+                        failed_hosts.add(host)
+                        result.report_failure(self._name, host, "timeout", name)
+                    continue
                 for name, value in result_.items():
                     if name not in self.state_paths:
                         logger.debug(

--- a/coco/core.py
+++ b/coco/core.py
@@ -15,7 +15,12 @@ from multiprocessing import Process, set_start_method
 
 import json
 import redis
-import aioredis
+
+import sys
+if (sys.version_info.minor <= 10):
+    import aioredis
+else:
+    from redis import asyncio as aioredis
 
 from sanic import Sanic, response
 

--- a/coco/endpoint.py
+++ b/coco/endpoint.py
@@ -297,11 +297,11 @@ class Endpoint:
 
         save_to_state = check_dict.get("save_reply_to_state", None)
         if save_to_state:
-            if not isinstance(save_to_state, str):
+            if not isinstance(save_to_state, (str, dict)):
                 raise ConfigError(
                     f"'save_reply_to_state' in check for '{name}' in '{self.name}"
                     f".conf' is of type '{type(save_to_state).__name__}' "
-                    f"(expected str)."
+                    f"(expected str or dict)."
                 )
             logger.debug(
                 f"Endpoint {self.name} will save replies to state: {save_to_state}."

--- a/coco/slack.py
+++ b/coco/slack.py
@@ -23,6 +23,7 @@ Modified from <https://github.com/imbolc/aiolog> and
 
 
 import logging
+import sys
 import asyncio
 import aiohttp
 
@@ -55,8 +56,14 @@ class LogMessageQueue:
             The event loop to use.
         """
         self.loop = loop
-        self.queue = asyncio.Queue(maxsize=self.queue_size, loop=loop)
-        self.task = asyncio.ensure_future(self.consume(), loop=loop)
+        if sys.version_info.minor < 10:
+            self.queue = asyncio.Queue(maxsize=self.queue_size, loop=loop)
+            self.task = asyncio.ensure_future(self.consume(), loop=loop)
+        else:
+            # loop keyword discontinued in python 3.10
+            self.queue = asyncio.Queue(maxsize=self.queue_size)
+            self.task = asyncio.ensure_future(self.consume())
+
         self.started = True
 
     def push(self, payload):

--- a/coco/worker.py
+++ b/coco/worker.py
@@ -12,7 +12,10 @@ import sys
 import time
 from urllib.parse import parse_qsl
 
-import aioredis
+if sys.version_info.minor <= 10:
+    import aioredis
+else:
+    from redis import asyncio as aioredis
 
 from . import Result
 from .scheduler import Scheduler

--- a/coco/worker.py
+++ b/coco/worker.py
@@ -1,7 +1,7 @@
 """
 coco worker.
 
-This module implements coco's worker. It runs in it's own process and empties the queue.
+This module implements coco's worker. It runs in its own process and empties the queue.
 """
 
 import asyncio

--- a/scripts/coco
+++ b/scripts/coco
@@ -4,6 +4,15 @@ import argparse
 import json  # orjson does not have an option to pretty-serialize (indent=2)
 import sys
 import yaml
+import os
+
+
+## TODO:
+#   - Create an endpoint that returns the full coco config
+#   - Environmental variable giving "coco_backend" target
+#   - If ^ is set, pull coco config from the backend. Parse from there.
+#   - Re-configure all endpoints each time the command is run, or save locally and sync sometimes?
+
 
 from coco import Endpoint, result, config
 
@@ -151,6 +160,14 @@ saved_states_parser = subparsers.add_parser(
 )
 saved_states_parser.set_defaults(
     func=Endpoint.client_send_request, type="GET", endpoint="saved-states", data={}
+)
+
+# coco config
+config_parser = subparsers.add_parser(
+    "get-coco-config", help=f"Return the configuration of coco (GET)."
+)
+config_parser.set_defaults(
+    func=Endpoint.client_send_request, type="GET", endpoint="get-coco-config", data={}
 )
 
 # save-state

--- a/scripts/coco
+++ b/scripts/coco
@@ -10,8 +10,6 @@ import requests
 from coco import Endpoint, result, config
 
 BACKEND = os.environ.get('COCO_BACKEND', None)
-if not "http" in BACKEND:
-    BACKEND = "http://" + BACKEND
 
 # result printing styles:
 STYLES = ["json", "yaml"]
@@ -53,6 +51,8 @@ except IndexError:
 
 if BACKEND is not None:
     # Retrieve config data from backend
+    if not "http" in BACKEND:
+        BACKEND = "http://" + BACKEND
     res = requests.get(BACKEND + "/get-coco-config")
     res.raise_for_status()
     if res.status_code == 200:

--- a/scripts/coco
+++ b/scripts/coco
@@ -5,16 +5,13 @@ import json  # orjson does not have an option to pretty-serialize (indent=2)
 import sys
 import yaml
 import os
-
-
-## TODO:
-#   - Create an endpoint that returns the full coco config
-#   - Environmental variable giving "coco_backend" target
-#   - If ^ is set, pull coco config from the backend. Parse from there.
-#   - Re-configure all endpoints each time the command is run, or save locally and sync sometimes?
-
+import requests
 
 from coco import Endpoint, result, config
+
+BACKEND = os.environ.get('COCO_BACKEND', None)
+if not "http" in BACKEND:
+    BACKEND = "http://" + BACKEND
 
 # result printing styles:
 STYLES = ["json", "yaml"]
@@ -53,7 +50,16 @@ except IndexError:
     conf = None
 
 # Find endpoint path in config
-coco_config = config.load_config(conf)
+
+if BACKEND is not None:
+    # Retrieve config data from backend
+    res = requests.get(BACKEND + "/get-coco-config")
+    res.raise_for_status()
+    if res.status_code == 200:
+        coco_config = res.json()['coco-config']["http://coco/"]['reply']
+else:
+    coco_config = config.load_config(conf)
+
 endpoints = get_endpoints(coco_config)
 
 # Global options


### PR DESCRIPTION
Among other things, adds a local endpoint that returns the config data of coco. This is needed for outriggers to have the coco client available on all nodes without having to have the endpoint directory on all nodes.

Further updates:
 - Adds support for python 3.8 to 3.11
 - Fixes how StateReplyCheck handles timeouts
 - Enable "save_to_state" to select a part of the returned data to save, and where