### PR TITLE
Report latency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a base image
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 ## The maintainer name and email
 LABEL maintainer="CHIME/FRB Collaboration"
@@ -7,7 +7,7 @@ LABEL maintainer="CHIME/FRB Collaboration"
 ADD . /coco
 
 RUN apt-get update && \
-    apt-get install -y apt-utils software-properties-common git build-essential curl \
+    apt-get install -y apt-utils git build-essential curl \
     libmariadb-dev libevent-dev && \
     pip install --use-deprecated=legacy-resolver flask && \
     pip install --use-deprecated=legacy-resolver -r /coco/requirements.txt && \

--- a/coco/core.py
+++ b/coco/core.py
@@ -428,7 +428,7 @@ class Core:
         Core endpoint. Passes all endpoint calls on to redis and blocks until completion.
         """
         # create a unique name for this task: <process ID>-<POSIX timestamp>
-        now = time.time()
+        now = time.perf_counter()
         name = f"{os.getpid()}-{now}"
 
         async with self.redis_async.client() as ra_cli:

--- a/coco/endpoint.py
+++ b/coco/endpoint.py
@@ -50,6 +50,7 @@ class Endpoint:
         self.type = conf.get("type", "GET")
         self.group = conf.get("group")
         self.callable = conf.get("callable", False)
+        self.report_latency = conf.get("report_latency", True)
         self.call_on_start = conf.get("call_on_start", False)
         self.forwarder = forwarder
         self.state = state
@@ -182,7 +183,7 @@ class Endpoint:
 
     def _load_internal_forward(self, dict_, list_):
         """
-        Load Forward's from the config dictionary, generate objects and place in list.
+        Load Forwards from the config dictionary, generate objects and place in list.
 
         Parameters
         ----------
@@ -512,6 +513,8 @@ class Endpoint:
                     self.state.write(path, value)
             self.write_timestamp()
             self.logger.debug("Success!")
+
+        result.report_latency = self.report_latency
 
         return result
 

--- a/coco/metric.py
+++ b/coco/metric.py
@@ -11,7 +11,7 @@ import aiohttp
 from prometheus_client.exposition import (
     MetricsHandler,
     choose_encoder,
-    _ThreadingSimpleServer,
+    ThreadingWSGIServer,
     REGISTRY,
 )
 from prometheus_client.parser import text_string_to_metric_families
@@ -53,7 +53,7 @@ def start_metrics_server(port, callbacks=None, addr=""):
     handler = CallbackMetricsHandler.factory(REGISTRY)
     if callbacks is not None:
         handler.callbacks += callbacks
-    httpd = _ThreadingSimpleServer((addr, port), handler)
+    httpd = ThreadingWSGIServer((addr, port), handler)
     t = threading.Thread(target=httpd.serve_forever)
     t.daemon = True
     t.start()

--- a/coco/metric.py
+++ b/coco/metric.py
@@ -11,7 +11,7 @@ import aiohttp
 from prometheus_client.exposition import (
     MetricsHandler,
     choose_encoder,
-    ThreadingWSGIServer,
+    _ThreadingSimpleServer,
     REGISTRY,
 )
 from prometheus_client.parser import text_string_to_metric_families
@@ -53,7 +53,7 @@ def start_metrics_server(port, callbacks=None, addr=""):
     handler = CallbackMetricsHandler.factory(REGISTRY)
     if callbacks is not None:
         handler.callbacks += callbacks
-    httpd = ThreadingWSGIServer((addr, port), handler)
+    httpd = _ThreadingSimpleServer((addr, port), handler)
     t = threading.Thread(target=httpd.serve_forever)
     t.daemon = True
     t.start()

--- a/coco/request_forwarder.py
+++ b/coco/request_forwarder.py
@@ -352,7 +352,7 @@ class RequestForwarder:
         """
         url = host.join_endpoint(endpoint)
         hostname, port = host.hostname, host.port
-        start_time = time.time()
+        start_time = time.perf_counter()
         status = "0"
         try:
             async with session.request(
@@ -363,20 +363,21 @@ class RequestForwarder:
                 timeout=aiohttp.ClientTimeout(timeout),
                 params=params,
             ) as response:
+                response_time = time.perf_counter() - start_time
                 try:
                     status = str(response.status)
                     return (
                         host,
-                        (await response.json(content_type=None), response.status),
+                        (await response.json(content_type=None), response.status, response_time),
                     )
                 except json.decoder.JSONDecodeError:
-                    return host, (await response.text(), response.status)
+                    return host, (await response.text(), response.status, response_time)
         except AsyncioTimeoutError:
-            return host, ("Timeout", 0)
+            return host, ("Timeout", 0, 0)
         except Exception as e:
-            return host, (str(e), 0)
+            return host, (str(e), 0, 0)
         finally:
-            response_time = time.time() - start_time
+            response_time = time.perf_counter() - start_time
             self.response_time.labels(
                 endpoint=endpoint, host=hostname, port=port
             ).observe(response_time)

--- a/coco/result.py
+++ b/coco/result.py
@@ -39,7 +39,7 @@ class Result:
     A status code of 0 signals an internal or connection error.
     """
 
-    def __init__(self, name, result=None, error=None, type_="CODES_OVERVIEW", report_latency=None):
+    def __init__(self, name, result=None, error=None, type_="CODES_OVERVIEW", report_latency=False):
         """
         Construct a Result.
 
@@ -55,6 +55,8 @@ class Result:
         type_ : str
             Type of report to use. See :class:`Result` for a full description. Default
             `CODES_OVERVIEW`.
+        report_latency : bool
+            Include external request latencies in report. Default False.
         """
         self._name = name
         self._result = {}

--- a/coco/result.py
+++ b/coco/result.py
@@ -39,7 +39,7 @@ class Result:
     A status code of 0 signals an internal or connection error.
     """
 
-    def __init__(self, name, result=None, error=None, type_="CODES_OVERVIEW"):
+    def __init__(self, name, result=None, error=None, type_="CODES_OVERVIEW", report_latency=None):
         """
         Construct a Result.
 
@@ -58,11 +58,13 @@ class Result:
         """
         self._name = name
         self._result = {}
+        self._latencies = {}
         self._status = {}
         self._add_reply(name, result)
         self._error = error
         self._embedded = None
         self.type = type_
+        self.report_latency = report_latency
         self._msg = None
         self._state = {}
         self._embedded = {}
@@ -134,6 +136,18 @@ class Result:
         return self._result
 
     @property
+    def latencies(self) -> Dict:
+        """
+        Latencies of requests sent to external hosts
+
+        Returns
+        -------
+        dict
+            Replies in a dict with endpoint names as keys
+        """
+        return self._latencies
+
+    @property
     def status(self) -> Dict:
         """
         Get all status codes saved in this result.
@@ -181,6 +195,7 @@ class Result:
             return
         self._success &= result.success
         self._result.update(result.results)
+        self._latencies.update(result.latencies)
         self._status.update(result.status)
         self._checks.update(result._checks)
         self._state.update(result._state)
@@ -209,9 +224,12 @@ class Result:
         if result:
             self._result[name] = {}
             self._status[name] = {}
+            self._latencies[name] = {}
             for h, r in result.items():
                 self._result[name][h] = r[0]
                 self._status[name][h] = r[1]
+                if len(r) == 3:
+                    self._latencies[name][h] = r[2]
         else:
             self._result[name] = None
             self._status[name] = None
@@ -294,11 +312,15 @@ class Result:
             for name in self._result:
                 if self._result[name]:
                     d[name] = {}
-                    for r in self._result[name].values():
+                    lats = []
+                    for h, r in self._result[name].items():
                         try:
                             d[name][str(r)] += 1
                         except KeyError:
                             d[name][str(r)] = 1
+                        lats.append(self._latencies[name].get(h, float("NaN")))
+                    if self.report_latency:
+                        d[name]['latency_stats'] = (max(lats), min(lats), sum(lats)/len(lats))
             return d
         if report_type == "FULL":
             for name in self._result:
@@ -308,6 +330,9 @@ class Result:
                         d[name][h.url()] = {}
                         d[name][h.url()]["reply"] = self._result[name][h]
                         d[name][h.url()]["status"] = self._status[name][h]
+                        if self.report_latency:
+                            d[name][h.url()]['latency'] = self._latencies[name].get(h, float("NaN"))
+
             return d
         if report_type == "CODES":
             d.update(self._status)
@@ -316,11 +341,15 @@ class Result:
             for name in self._result:
                 if self._status[name]:
                     d[name] = {}
-                    for s in self._status[name].values():
+                    lats = []
+                    for h,s in self._status[name].items():
                         try:
                             d[name][str(s)] += 1
                         except KeyError:
                             d[name][str(s)] = 1
+                        lats.append(self._latencies[name].get(h, float("NaN")))
+                    if self.report_latency:
+                        d[name]['latency_stats'] = (max(lats), min(lats), sum(lats)/len(lats))
             return d
         msg = f"Unknown report type: {report_type}"
         logger.error(msg)

--- a/coco/worker.py
+++ b/coco/worker.py
@@ -103,10 +103,12 @@ def main_loop(
             ] = await conn.execute_command(
                 "hmget", name, "method", "endpoint", "request", "params", "received"
             )
+            queue_wait=None
             if received:
                 received = float(received)
+                queue_wait = time.perf_counter() - received
                 forwarder.queue_wait_time.labels(endpoint_name).observe(
-                    time.time() - received
+                    queue_wait
                 )
 
             await conn.execute_command("del", name)
@@ -154,6 +156,9 @@ def main_loop(
                 # Transform any Result into a report so it can be serialised
                 if isinstance(result, Result):
                     result = result.report()
+                if endpoint.report_latency:
+                    result['queue_wait'] = queue_wait
+
                 code = 200
 
             # Process a known exception source into a response

--- a/coco/worker.py
+++ b/coco/worker.py
@@ -154,7 +154,6 @@ def main_loop(
                 # Transform any Result into a report so it can be serialised
                 if isinstance(result, Result):
                     result = result.report()
-
                 code = 200
 
             # Process a known exception source into a response

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -9,7 +9,7 @@ from coco.test import endpoint_farm
 ENDPT_NAME = "test"
 PORT = 12055
 CONFIG = {"log_level": "INFO", "port": PORT}
-ENDPOINTS = {ENDPT_NAME: {"group": "test", "values": {"foo": "int", "bar": "str"}}}
+ENDPOINTS = {ENDPT_NAME: {"group": "test", "report_latencies": True, "values": {"foo": "int", "bar": "str"}}}
 N_CALLS = 2
 
 
@@ -82,15 +82,32 @@ def test_url_args(farm, runner):
     assert response.status_code == 200
     response = response.json()
 
-    print(response)
-
     assert ENDPT_NAME in response
     for h in farm.hosts:
         assert h in response[ENDPT_NAME]
         assert "status" in response[ENDPT_NAME][h]
         assert "reply" in response[ENDPT_NAME][h]
         assert "params" in response[ENDPT_NAME][h]["reply"]
+        assert "latency" in response[ENDPT_NAME][h]    # Check that per-host latencies are returned
 
         request.update({"params": params})
         assert response[ENDPT_NAME][h]["status"] == 200
         assert response[ENDPT_NAME][h]["reply"] == request
+
+
+def test_latency_stats(farm, runner):
+    """Test if latency stats are returned from external endpoint"""
+    request = {"foo": 0, "bar": "1337"}
+    request_full = request.copy()
+    params = {"cat": "1", "hat": "rat"}
+    query_str = "&".join([f"{k}={params[k]}" for k in params])
+
+    response = requests.get(
+        f"http://localhost:{PORT}/{ENDPT_NAME}?{query_str}", json=request
+    )
+    assert response.status_code == 200
+    response = response.json()
+
+    print(response)
+
+    assert "latency_stats" in response[ENDPT_NAME]


### PR DESCRIPTION
We would like to track the latency of baseband dump requests between coco and X-engine nodes. These changes calculate these latencies for External forwards and return them with the results if the endpoint has a flag "report_latency" set to True. Depending on the report type, either latencies to each host in the group are returned (report_type=FULL) or min, max, and mean latencies across the group are returned (report_type OVERVIEW or similar).

Latencies are already passed to prometheus when requests fail, but this packages that information in the REST framework instead.