### PR TITLE
fix: Drop aioredis

### DIFF
--- a/coco/core.py
+++ b/coco/core.py
@@ -10,20 +10,14 @@ import datetime
 import json
 import logging
 import os
-import sys
 import time
 from multiprocessing import Process, set_start_method
 from pathlib import Path
 
 import click
 import redis
-
-if sys.version_info.minor <= 10:
-    import aioredis
-else:
-    from redis import asyncio as aioredis
-
 from comet import CometError, Manager
+from redis import asyncio as aioredis
 from sanic import Sanic, response
 
 from . import config, slack, wait, worker

--- a/coco/worker.py
+++ b/coco/worker.py
@@ -12,10 +12,7 @@ import sys
 import time
 from urllib.parse import parse_qsl
 
-if sys.version_info.minor <= 10:
-    import aioredis
-else:
-    from redis import asyncio as aioredis
+from redis import asyncio as aioredis
 
 from . import Result, slack
 from .exceptions import CocoException, InvalidMethod, InvalidPath, InvalidUsage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ license-files = [ "LICENSE" ]
 dependencies = [
   "comet @ git+https://github.com/chime-experiment/comet.git",
   "aiohttp",
-  "aioredis>=2.0",
   "async_timeout",
   "atomicwrites",
   "click",
@@ -30,7 +29,7 @@ dependencies = [
   "msgpack",
   "prometheus_client<0.8",
   "pyyaml",
-  "redis",
+  "redis>=4.2.0",
   "requests",
   "sanic>=20.6.0"
 ]


### PR DESCRIPTION
`aioredis` was merged into `redis` proper in `redis-4.2`. `aioredis` is not supported after Python-3.10.