### PR TITLE
Start of test-suite rewrite

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ['3.10', '3.12']
+        python_version: ['3.10', '3.12', '3.14']
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -40,38 +40,26 @@ jobs:
       - name: Run ruff check
         run: ruff check . scripts/coco
 
-#  tests:
-#    runs-on: ubuntu-latest
-#    strategy:
-#      matrix:
-#        python_version: ['3.10', '3.12']
-#    steps:
-#      - uses: actions/checkout@v6
-#
-#      - name: Set up Python
-#        uses: actions/setup-python@v6
-#        with:
-#          python-version: ${{ matrix.python_version }}
-#
-#      - name: Install apt dependencies
-#        run: |
-#          sudo apt-get update
-#          sudo apt-get install -y python3-sphinx libevent-dev libhdf5-dev g++
-#      - name: Install pip dependencies
-#        run: |
-#          pip install flask coverage pytest-cov sphinx_rtd_theme
-#          pip install .
-#
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python_version: ['3.10', '3.12']
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python_version }}
+
+      - name: Install pip dependencies
+        run: pip install .[test]
+
 #      - name: Start Redis
 #        uses: supercharge/redis-github-action@1.8.1
 #        with:
 #          redis-version: 5
 #
-#      - name: Build docs
-#        run: cd docs && make html && cd ..
-#
-#      - name: Build test utils
-#        run: MAKEFLAGS="-j 2" g++ -o tests/hash tests/hash.cpp --std=c++11 -lssl -lcrypto
-#
-#      - name: Unit tests
-#        run: PYTHONPATH=. TEST_DIR="GITHUB_WORKSPACE/tests/simulate-chime/" pytest -xs --cov-report term-missing:skip-covered --cov=coco tests/test_*.py
+      - name: Run unit tests
+        run: pytest -v tests

--- a/coco/__init__.py
+++ b/coco/__init__.py
@@ -3,41 +3,6 @@
 import logging
 from importlib.metadata import PackageNotFoundError, version
 
-from .check import (
-    Check,
-    IdenticalReplyCheck,
-    ReplyCheck,
-    StateHashReplyCheck,
-    StateReplyCheck,
-    TypeReplyCheck,
-    ValueReplyCheck,
-)
-from .core import Core
-from .endpoint import Endpoint, LocalEndpoint
-from .request_forwarder import CocoForward, ExternalForward, RequestForwarder
-from .result import Result
-from .state import State
-from .task_pool import TaskPool
-
-__all__ = [
-    "Check",
-    "CocoForward",
-    "Core",
-    "Endpoint",
-    "ExternalForward",
-    "IdenticalReplyCheck",
-    "LocalEndpoint",
-    "ReplyCheck",
-    "RequestForwarder",
-    "Result",
-    "State",
-    "StateHashReplyCheck",
-    "StateReplyCheck",
-    "TaskPool",
-    "TypeReplyCheck",
-    "ValueReplyCheck",
-]
-
 logger = logging.getLogger(__name__)
 handler = logging.StreamHandler()
 formatter = logging.Formatter(

--- a/coco/config.py
+++ b/coco/config.py
@@ -149,7 +149,10 @@ def load_config(path: str | os.PathLike | None = None):
     ]
 
     if "COCO_CONFIG_FILE" in os.environ:
-        config_files.append(os.environ["COCO_CONFIG_FILE"])
+        envpath = os.environ["COCO_CONFIG_FILE"]
+        config_files.append(envpath)
+    else:
+        envpath = None
 
     if path is not None:
         config_files.append(path)
@@ -161,15 +164,32 @@ def load_config(path: str | os.PathLike | None = None):
         absfile = Path(cfile).expanduser().resolve()
 
         if not absfile.exists():
-            logger.debug(f"Could not find config file {absfile}")
+            # Explicitly-specified paths must exist
+            if path and cfile == path:
+                raise click.ClickException(
+                    f"Config file specified on command line not found: {absfile}"
+                )
+            if envpath and cfile == envpath:
+                raise click.ClickException(
+                    f"Config file specified via COCO_CONFIG_FILE not found: {absfile}"
+                )
+            logger.debug(f"Config file {absfile} not present.")
             continue
 
         any_exist = True
 
         logger.info(f"Loading config file {cfile}")
 
-        with absfile.open("r", encoding="utf-8") as fh:
-            conf = yaml.safe_load(fh)
+        try:
+            with absfile.open("r", encoding="utf-8") as fh:
+                conf = yaml.safe_load(fh)
+        except (OSError, UnicodeDecodeError, yaml.YAMLError) as e:
+            raise click.ClickException(f"Error reading {absfile}: {e}") from e
+
+        if type(conf) is not dict:
+            raise click.ClickException(
+                f"Invalid config file {absfile}: expected a YAML map."
+            )
 
         config = merge_dict_tree(config, conf)
 
@@ -270,11 +290,19 @@ def _load_endpoint_config(config: dict) -> None:
             # Remove .conf from the config file name to get the name of the endpoint
             name = endpoint_file.stem
 
-            with endpoint_file.open("r") as fh:
-                try:
+            try:
+                with endpoint_file.open("r", encoding="utf-8") as fh:
                     conf = yaml.safe_load(fh)
-                except yaml.YAMLError as exc:
-                    logger.error(f"Failure reading YAML file {endpoint_file}: {exc}")
+            except (OSError, UnicodeDecodeError, yaml.YAMLError) as e:
+                raise click.ClickException(
+                    f"Failure reading endpoint {endpoint_file}: {e}"
+                ) from e
+
+            # Only mapping are supported
+            if type(conf) is not dict:
+                raise click.ClickException(
+                    f"Invalid endpoint {endpoint_file}: expected a YAML map."
+                )
 
             conf["name"] = name
 

--- a/coco/core.py
+++ b/coco/core.py
@@ -46,17 +46,6 @@ except RuntimeError:
     pass
 
 
-def _check_log_level(level: str) -> str:
-    """Vet log level `level`.
-
-    If `level` is invalid, raises ClickException.  Otherwise, returns `level`.
-    """
-
-    if level and level not in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]:
-        raise click.ClickException(f"Log level {level} is not valid")
-    return level
-
-
 class Core:
     """
     The core module.
@@ -314,11 +303,14 @@ class Core:
         self.config = config.load_config(config_path)
 
         # Set log level, if valid
-        self.log_level = _check_log_level(self.config["log_level"])
+        self.log_level = self.config["log_level"]
 
-        logger.setLevel(self.log_level)
-        # Also set log level for root logger, inherited by all
-        logging.getLogger().setLevel(self.log_level)
+        try:
+            logger.setLevel(self.log_level)
+            # Also set log level for root logger, inherited by all
+            logging.getLogger().setLevel(self.log_level)
+        except ValueError as e:
+            raise click.ClickException(f"Unable to set log level: {e}") from e
 
         # Get the state storage and blocklist path, if it's not absolute then
         # it is resolved relative to the config directory

--- a/coco/core.py
+++ b/coco/core.py
@@ -25,7 +25,7 @@ from .endpoint import (
     Endpoint,
     LocalEndpoint,
 )
-from .exceptions import ConfigError, InternalError
+from .exceptions import InternalError
 from .request_forwarder import (
     CocoForward,
     RequestForwarder,
@@ -44,6 +44,17 @@ try:
     set_start_method("fork", force=True)
 except RuntimeError:
     pass
+
+
+def _check_log_level(level: str) -> str:
+    """Vet log level `level`.
+
+    If `level` is invalid, raises ClickException.  Otherwise, returns `level`.
+    """
+
+    if level and level not in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]:
+        raise click.ClickException(f"Log level {level} is not valid")
+    return level
 
 
 class Core:
@@ -73,10 +84,10 @@ class Core:
         # doesn't fail.
         self.qworker = None
         self.state = None
+        self.redis_sync = None
 
         # Load the config
         self._load_config(conf)
-        logger.setLevel(self.config["log_level"])
 
         if reset is True:
             # Reset the internal state
@@ -86,7 +97,7 @@ class Core:
         try:
             timeout = str2total_seconds(self.config["timeout"])
         except Exception as e:
-            raise ConfigError(
+            raise click.ClickException(
                 f"Failed parsing value 'timeout' ({self.config['timeout']})."
             ) from e
         self.forwarder = RequestForwarder(
@@ -108,7 +119,7 @@ class Core:
         try:
             self.frontend_timeout = str2total_seconds(self.config["frontend_timeout"])
         except Exception as e:
-            raise ConfigError(
+            raise click.ClickException(
                 "Failed parsing value 'frontend_timeout' "
                 f"({self.config['frontend_timeout']})."
             ) from e
@@ -162,7 +173,7 @@ class Core:
 
         Join the worker process.
         """
-        if not self.check_config:
+        if self.redis_sync and not self.check_config:
             logger.info("Joining worker process...")
             try:
                 self.redis_sync.rpush("queue", "coco_shutdown")
@@ -276,7 +287,9 @@ class Core:
         try:
             enable_comet = self.config["comet_broker"]["enabled"]
         except KeyError as e:
-            raise ConfigError("Missing config value 'comet_broker/enabled'.") from e
+            raise click.ClickException(
+                "Missing config value 'comet_broker/enabled'."
+            ) from e
         if enable_comet:
             try:
                 comet_host = self.config["comet_broker"]["host"]
@@ -300,26 +313,28 @@ class Core:
     def _load_config(self, config_path: os.PathLike | None):
         self.config = config.load_config(config_path)
 
-        self.log_level = self.config["log_level"]
-        logger.setLevel(self.config["log_level"])
+        # Set log level, if valid
+        self.log_level = _check_log_level(self.config["log_level"])
+
+        logger.setLevel(self.log_level)
         # Also set log level for root logger, inherited by all
-        logging.getLogger().setLevel(self.config["log_level"])
+        logging.getLogger().setLevel(self.log_level)
 
         # Get the state storage and blocklist path, if it's not absolute then
         # it is resolved relative to the config directory
         self.blocklist_path = Path(self.config["blocklist_path"])
         if not self.blocklist_path.is_absolute():
-            raise ConfigError(
+            raise click.ClickException(
                 f'Blocklist path "{self.config["blocklist_path"]}" must be absolute.'
             )
         storage_path = Path(self.config["storage_path"])
         if not storage_path.is_absolute():
-            raise ConfigError(
+            raise click.ClickException(
                 f'Storage path "{self.config["storage_path"]}" must be absolute.'
             )
         if not storage_path.is_dir():
-            raise ConfigError(
-                f'Storage path "{self.config["storage_path"]}" doesn\'t exist.'
+            raise click.ClickException(
+                f'Storage path "{self.config["storage_path"]}" is not a directory.'
             )
 
         # Read groups
@@ -329,7 +344,7 @@ class Core:
 
         # Init state, tries loading from persistent storage
         self.state = State(
-            self.config["log_level"],
+            self.log_level,
             storage_path,
             self.config["load_state"],
             self.config["exclude_from_reset"],
@@ -396,7 +411,7 @@ class Core:
                     if isinstance(a, dict):
                         keys = list(a.keys())
                         if len(keys) != 1:
-                            raise ConfigError(
+                            raise click.ClickException(
                                 f"coco.endpoint: bad config format for endpoint "
                                 f"`{e.name}`: `{a}`. Should be either a string or "
                                 "have the format:\n"
@@ -410,7 +425,7 @@ class Core:
                     if isinstance(a, CocoForward):
                         a = a.name
                     if a not in self.endpoints:
-                        raise ConfigError(
+                        raise click.ClickException(
                             f"coco.endpoint: endpoint `{a}` found in config for "
                             f"`{e.name}` does not exist."
                         )
@@ -489,7 +504,7 @@ class Core:
         )
 
 
-@click.group()
+@click.command()
 @click.option("--check-config", is_flag=True, default=False, help="Check config only")
 @click.option(
     "-c",

--- a/coco/worker.py
+++ b/coco/worker.py
@@ -14,8 +14,9 @@ from urllib.parse import parse_qsl
 
 from redis import asyncio as aioredis
 
-from . import Result, slack
+from . import slack
 from .exceptions import CocoException, InvalidMethod, InvalidPath, InvalidUsage
+from .result import Result
 from .scheduler import Scheduler
 
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,12 @@ dependencies = [
   "sanic>=20.6.0"
 ]
 
+[project.optional-dependencies]
+test = [
+  "pyfakefs >= 5.4",
+  "pytest >= 7.0"
+]
+
 [project.scripts]
 cocod = "coco.core:cocod"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,122 @@
+"""Common test fixtures"""
+
+import traceback
+
+import pytest
+import yaml
+
+from coco import config
+
+
+def pytest_configure(config):
+    """This function extends the pytest config file."""
+
+    config.addinivalue_line(
+        "markers",
+        "no_default_config(*flag): "
+        "If flag is True, the default test config is not used.",
+    )
+    config.addinivalue_line(
+        "markers",
+        "coco_config(*config_dict): "
+        "used to set the coco.config for testing.  config_dict"
+        "is merged with the default config.",
+    )
+
+
+@pytest.fixture
+def coco_config(request, fs):
+    """Fixture creating the config file for CLI tests."""
+
+    # Check whether to skip the default config
+    marker = request.node.get_closest_marker("no_default_config")
+    if marker is not None:
+        no_default_config = bool(marker.args[0])
+    else:
+        no_default_config = False
+
+    if no_default_config:
+        _config = {}
+    else:
+        _config = {
+            "host": "cocohost",
+            "endpoint_dir": "/etc/coco/endpoints",
+            "groups": ["defgroup"],
+        }
+
+    # Merge in any test-specific config
+    marker = request.node.get_closest_marker("coco_config")
+    if marker is not None:
+        _config = config.merge_dict_tree(_config, marker.args[0])
+
+    # If there's no config, create nothing.
+    if _config:
+        # Dump it to a file
+        fs.create_file("/etc/coco/coco.conf", contents=yaml.dump(_config))
+
+        if not no_default_config:
+            # Create a default endpoint, so something's there.
+            fs.create_file(
+                "/etc/coco/endpoints/endpoint.conf",
+                contents=yaml.dump({"group": "defgroup"}),
+            )
+
+
+@pytest.fixture
+def default_paths(fs):
+    """Ensure cocod's default paths exist in the fake filesystem."""
+
+    # Blocklist
+    fs.create_file("/var/lib/coco/blocklist.json")
+
+    # storage_path
+    fs.create_dir("/var/lib/coco/state/")
+
+
+@pytest.fixture
+def cocod(coco_config, default_paths):
+    """Set up coco daemon tests using click
+
+    Yields a wrapper around click.testing.CliRunner().invoke.
+    The first parameter passed to the wrapper should be
+    the expected exit code.  Other parameters are passed
+    to CliRunner.invoke (including the list of command
+    line parameters).
+
+    The wrapper performs rudimentary checks on the result,
+    then returns the click.result so the caller can inspect
+    the result further, if desired.
+    """
+
+    from click.testing import CliRunner
+
+    # Create the runner before the test starts
+    runner = CliRunner()
+
+    def _cli_wrapper(expected_result, *args, **kwargs):
+        from coco.core import cocod
+
+        nonlocal runner
+
+        result = runner.invoke(cocod, *args, **kwargs)
+
+        # Show traceback if one was created
+        if (
+            result.exit_code
+            and result.exc_info
+            and type(result.exception) is not SystemExit
+        ):
+            traceback.print_exception(*result.exc_info)
+
+        # Print output so it appears in the test log on failure
+        print(result.output)
+
+        assert result.exit_code == expected_result
+        if expected_result:
+            assert type(result.exception) is SystemExit
+        else:
+            assert result.exception is None
+
+        return result
+
+    yield _cli_wrapper

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,181 @@
+"""Test coco/config.py"""
+
+import click
+import pytest
+import yaml
+
+from coco import config
+
+
+@pytest.mark.no_default_config(True)
+def test_no_config(coco_config):
+    """No config causes an error."""
+    with pytest.raises(click.ClickException):
+        config.load_config()
+
+
+@pytest.mark.no_default_config(True)
+@pytest.mark.coco_config({"test": "test"})
+def test_missing_required(coco_config):
+    """Test reporting missing required config."""
+
+    with pytest.raises(click.ClickException) as exinfo:
+        config.load_config()
+
+    # Run through the skeleton and make sure everything is reported
+    for name, val in config._config_skeleton.items():
+        if val is config.RequiredValue:
+            assert name in exinfo.value.args[0]
+
+
+def test_config_path(fs, coco_config):
+    """Test that a path passed in to load_config is loaded."""
+
+    # Create a test file
+    fs.create_file("/test/test.conf", contents=yaml.dump({"host": "canary"}))
+
+    result = config.load_config("/test/test.conf")
+    assert result["host"] == "canary"
+
+
+def test_config_envar(fs, monkeypatch, coco_config):
+    """Test that a path passed in via envar loaded."""
+
+    # Create a test file
+    fs.create_file("/test/test.conf", contents=yaml.dump({"host": "canary"}))
+
+    monkeypatch.setenv("COCO_CONFIG_FILE", "/test/test.conf")
+    result = config.load_config()
+    assert result["host"] == "canary"
+
+
+def test_config_ordering(fs, monkeypatch, coco_config):
+    """A passed-in path supercedes everything else."""
+
+    # Create some test file
+    fs.create_file(
+        "/test/envar.conf", contents=yaml.dump({"host": "envar", "envar_seen": True})
+    )
+    fs.create_file(
+        "/test/cmdline.conf",
+        contents=yaml.dump({"host": "cmdline", "cmdline_seen": True}),
+    )
+
+    monkeypatch.setenv("COCO_CONFIG_FILE", "/test/envar.conf")
+    result = config.load_config("/test/cmdline.conf")
+    assert result["host"] == "cmdline"
+    assert "envar_seen" in result
+    assert "cmdline_seen" in result
+
+
+def test_missing_files(monkeypatch, coco_config):
+    """User-specified config files must exist."""
+
+    with pytest.raises(click.ClickException):
+        config.load_config("/missing/file")
+
+    monkeypatch.setenv("COCO_CONFIG_FILE", "/missing/file")
+    with pytest.raises(click.ClickException):
+        config.load_config()
+
+
+def test_default_config(coco_config):
+    """Loading the default test config should work."""
+    result = config.load_config()
+
+    # Result should be the test default merged with coco's default
+    expected_result = config.merge_dict_tree(
+        config._config_skeleton,
+        {
+            "host": "cocohost",
+            "endpoint_dir": "/etc/coco/endpoints",
+            "groups": ["defgroup"],
+            "endpoints": [{"group": "defgroup", "name": "endpoint"}],
+        },
+    )
+
+    assert result == expected_result
+
+
+def test_utf8_error(fs, coco_config):
+    """Try loading a non-UTF-8 config file."""
+
+    # This contains a UTF-16 surrogate, U+D801, encoded in UTF-8 to the
+    # forbidden byte sequence ED A0 81
+    fs.create_file("/test/test.conf", contents=b"---\nhost: \xed\xa0\x81\n")
+
+    with pytest.raises(click.ClickException):
+        config.load_config("/test/test.conf")
+
+
+def test_yaml_error(fs, coco_config):
+    """Test reading a non-YAML config file"""
+    fs.create_file("/test/test.conf", contents="a: b: c:\n")
+
+    with pytest.raises(click.ClickException):
+        config.load_config("/test/test.conf")
+
+
+def test_no_map(fs, coco_config):
+    """Test reading a non-mapping YAML config file"""
+    fs.create_file("/test/test.conf", contents="---\njust_a_scalar\n")
+
+    with pytest.raises(click.ClickException):
+        config.load_config("/test/test.conf")
+
+
+def test_endpoint_skipping(fs, coco_config):
+    """Test skipped files in the endpoint dir."""
+
+    # This is skipped because it doesn't end in ".conf"
+    fs.create_file(
+        "/etc/coco/endpoints/no_conf.yaml", contents=yaml.dump({"group": "defgroup"})
+    )
+
+    # This is skipped because endpoints with a leading _ are disabled.
+    fs.create_file(
+        "/etc/coco/endpoints/_disabled.conf", contents=yaml.dump({"group": "defgroup"})
+    )
+
+    # This one should work
+    fs.create_file(
+        "/etc/coco/endpoints/check.conf", contents=yaml.dump({"group": "defgroup"})
+    )
+
+    result = config.load_config()
+
+    # The only endpoints should be "check" and the fixture-created "endpoint"
+    assert len(result["endpoints"]) == 2
+    assert {endpoint["name"] for endpoint in result["endpoints"]} == {
+        "check",
+        "endpoint",
+    }
+
+
+def test_utf8_endpoint_error(fs, coco_config):
+    """Try loading a non-UTF-8 endpoint."""
+
+    # This contains a UTF-16 surrogate, U+D801, encoded in UTF-8 to the
+    # forbidden byte sequence ED A0 81
+    fs.create_file(
+        "/etc/coco/endpoints/test.conf", contents=b"---\ngroup: \xed\xa0\x81\n"
+    )
+
+    with pytest.raises(click.ClickException):
+        config.load_config()
+
+
+def test_yaml_endpoint_error(fs, coco_config):
+    """Test reading a non-YAML endpoint"""
+    fs.create_file("/etc/coco/endpoints/test.conf", contents="a: b: c\n")
+
+    with pytest.raises(click.ClickException):
+        config.load_config()
+
+
+def test_no_map_endpoing(fs, coco_config):
+    """Test reading a non-mapping YAML endpoint"""
+    fs.create_file("/etc/coco/endpoints/test.conf", contents="---\njust_a_scalar\n")
+
+    with pytest.raises(click.ClickException):
+        config.load_config()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,54 @@
+"""Test the coco daemon (coco.core)."""
+
+import pytest
+
+import coco.core
+
+
+def test_help(cocod):
+    """Test cocod --help"""
+
+    result = cocod(0, ["--help"])
+    assert coco.core.cocod.__doc__ in result.output
+
+
+@pytest.mark.coco_config({"log_level": "INVALID"})
+def test_bad_log_level(cocod):
+    """Try invalid log_level."""
+
+    result = cocod(1)
+    assert "INVALID" in result.output
+
+
+@pytest.mark.coco_config({"blocklist_path": "invalid_blocklist_path"})
+def test_relative_blocklist_path(cocod):
+    """blocklist_path must be absolute"""
+
+    result = cocod(1)
+    assert "invalid_blocklist_path" in result.output
+
+
+@pytest.mark.coco_config({"storage_path": "invalid_storage_path"})
+def test_relative_storage_path(cocod):
+    """storage_path must be absolute"""
+
+    result = cocod(1)
+    assert "invalid_storage_path" in result.output
+
+
+@pytest.mark.coco_config({"storage_path": "/storage/path"})
+def test_storage_missing(fs, cocod):
+    """storage_path must exist"""
+
+    result = cocod(1)
+    assert "/storage/path" in result.output
+
+
+@pytest.mark.coco_config({"storage_path": "/storage/path"})
+def test_storage_path_not_dir(fs, cocod):
+    """storage_path must be a directory"""
+
+    # Create a file at the storage_path
+    fs.create_file("/storage/path", contents="")
+    result = cocod(1)
+    assert "/storage/path" in result.output


### PR DESCRIPTION
Unit tests for `cocod` up to the end of config file loading.

That is, up to (but not including) the point where the `State` is created.  This is includes unit tests for all of `coco/config.py` and a bit of `coco/core.py`.

The revamped test suite uses `pyfakefs` for test isolation.  I've written a small number of fixtures in the pytest-default `conftest.py` file to simplify tests.

Specific fixes / changes:

* Removed all the top-level imports into `coco/__init__.py` which _might_ have made sense if coco were being used as a library package, but doesn't seem helpful here and is causing problems with circular imports.
* If an explicitly-given config file (i.e. via `-c` on the command line and/or the `COCO_CONFIG_FILE` environmental variable) is missing, cocod now exits with a fatal error.  Previously it would silently ignore these missing files.
* I/O, character encoding and YAML errors in config files and endpoints now produce meaningful error messages.
* An invalid "log_level" in the config is now handled gracefully via fatal error.
* An early exit of `cocod` no longer crashes on exit with a `AttributeError` (due to `redis_sync` not being defined early enough).
* Config errors noticed by `cocod` are now reported using `click.ClickException` instead of coco's `ConfigError` for proper CLI exit.