### PR TITLE
fix(state): Don't monkeypatch PyYAML

### DIFF
--- a/coco/config.py
+++ b/coco/config.py
@@ -102,6 +102,8 @@ from pathlib import Path
 import click
 import yaml
 
+from .util import yaml_load
+
 logger = logging.getLogger(__name__)
 
 # TODO: pretty much all logging messages config out of this module are ignored
@@ -182,14 +184,9 @@ def load_config(path: str | os.PathLike | None = None):
 
         try:
             with absfile.open("r", encoding="utf-8") as fh:
-                conf = yaml.safe_load(fh)
-        except (OSError, UnicodeDecodeError, yaml.YAMLError) as e:
+                conf = yaml_load(fh)
+        except (OSError, ValueError, UnicodeDecodeError, yaml.YAMLError) as e:
             raise click.ClickException(f"Error reading {absfile}: {e}") from e
-
-        if type(conf) is not dict:
-            raise click.ClickException(
-                f"Invalid config file {absfile}: expected a YAML map."
-            )
 
         config = merge_dict_tree(config, conf)
 
@@ -292,17 +289,11 @@ def _load_endpoint_config(config: dict) -> None:
 
             try:
                 with endpoint_file.open("r", encoding="utf-8") as fh:
-                    conf = yaml.safe_load(fh)
-            except (OSError, UnicodeDecodeError, yaml.YAMLError) as e:
+                    conf = yaml_load(fh)
+            except (OSError, ValueError, UnicodeDecodeError, yaml.YAMLError) as e:
                 raise click.ClickException(
                     f"Failure reading endpoint {endpoint_file}: {e}"
                 ) from e
-
-            # Only mapping are supported
-            if type(conf) is not dict:
-                raise click.ClickException(
-                    f"Invalid endpoint {endpoint_file}: expected a YAML map."
-                )
 
             conf["name"] = name
 

--- a/coco/state.py
+++ b/coco/state.py
@@ -5,23 +5,12 @@ import os
 from pathlib import Path
 
 import jinja2
-import yaml
 
 from .exceptions import InternalError, InvalidUsage
 from .result import Result
-from .util import Host, PersistentState, hash_dict
+from .util import Host, PersistentState, hash_dict, yaml_load
 
 logger = logging.getLogger(__name__)
-
-
-def my_construct_mapping(self, node, deep=False):
-    """Make yaml loader always convert integer keys to strings."""
-    data = self.construct_mapping_org(node, deep)
-    return {(str(key) if isinstance(key, int) else key): data[key] for key in data}
-
-
-yaml.SafeLoader.construct_mapping_org = yaml.SafeLoader.construct_mapping
-yaml.SafeLoader.construct_mapping = my_construct_mapping
 
 
 class State:
@@ -526,7 +515,7 @@ def load_kotekan_config_file(file: str | Path):
     if extension != ".j2":
         # This is just a yaml file
         with open(file) as fh:
-            config_yaml = yaml.safe_load(fh)
+            config_yaml = yaml_load(fh)
     else:
         # This is a jinja template
         env = jinja2.Environment(
@@ -534,6 +523,6 @@ def load_kotekan_config_file(file: str | Path):
         )
         template = env.get_template(name)
         # Convert to yaml with no extra arguments
-        config_yaml = yaml.safe_load(template.render())
+        config_yaml = yaml_load(template.render())
 
     return config_yaml

--- a/coco/util.py
+++ b/coco/util.py
@@ -15,11 +15,51 @@ from datetime import timedelta
 from urllib.parse import urlparse
 
 import msgpack
+import yaml
 from atomicwrites import atomic_write
 
 TIMEDELTA_REGEX = re.compile(
     r"((?P<hours>\d+?)h)?((?P<minutes>\d+?)m)?((?P<seconds>\d+?)s)?"
 )
+
+
+def yaml_load(stream) -> dict:
+    """Load YAML from a stream and then ensure it's properly formatted.
+
+    Parameters
+    ----------
+    stream : IO
+        the I/O stream to load
+
+    Returns
+    -------
+    dict
+        The parsed YAML mapping.
+
+    Raises
+    ------
+    ValueError
+        The loaded YAML wasn't a mapping
+    YAMLError
+        The stream didn't provide parsable YAML
+    """
+
+    def _stringify(obj):
+        """Return obj with all dict keys converted to strings."""
+        if type(obj) is dict:
+            return {str(key): _stringify(value) for key, value in obj.items()}
+        if type(obj) is list:
+            return [_stringify(elem) for elem in obj]
+        return obj
+
+    mapping = yaml.safe_load(stream)
+
+    # We only support mappings
+    if type(mapping) is not dict:
+        raise ValueError("YAML mapping expected")
+
+    # stringify keys in the mapping, to any depth
+    return _stringify(mapping)
 
 
 def str2timedelta(time_str):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -179,3 +179,19 @@ def test_no_map_endpoing(fs, coco_config):
 
     with pytest.raises(click.ClickException):
         config.load_config()
+
+
+@pytest.mark.coco_config(
+    {1234: "test", "subdict": {5.6: "test"}, "dictlist": [{True: "test"}]}
+)
+def test_str_keys(coco_config):
+    """All config keys are strings."""
+
+    result = config.load_config()
+
+    assert "1234" in result
+    assert 1234 not in result
+    assert "5.6" in result["subdict"]
+    assert 5.6 not in result["subdict"]
+    assert "True" in result["dictlist"][0]
+    assert True not in result["dictlist"][0]


### PR DESCRIPTION
Instead of the monkeypatching of PyYAML's `SafeLoader`, there's now just a wrapper around the `safe_load` call that does post-processing on the returned `dict`.

Requires #262