### PR TITLE
fix(util): Fixes for coco.util with unit tests

### DIFF
--- a/coco/util.py
+++ b/coco/util.py
@@ -11,16 +11,14 @@ import hashlib
 import json
 import os
 import re
+import tempfile
 from datetime import timedelta
 from urllib.parse import urlparse
 
 import msgpack
 import yaml
-from atomicwrites import atomic_write
 
-TIMEDELTA_REGEX = re.compile(
-    r"((?P<hours>\d+?)h)?((?P<minutes>\d+?)m)?((?P<seconds>\d+?)s)?"
-)
+_TIMEDELTA_REGEX = None
 
 
 def yaml_load(stream) -> dict:
@@ -77,6 +75,8 @@ def str2timedelta(time_str):
     :class:`datetime.timedelta`
         The converted timedelta.
     """
+    global _TIMEDELTA_REGEX
+
     # Check for simple numeric seconds
     try:
         seconds = float(time_str)
@@ -85,7 +85,14 @@ def str2timedelta(time_str):
         pass
 
     # Otherwise parse time
-    parts = TIMEDELTA_REGEX.match(time_str)
+
+    # Compile the pattern the first time it's needed
+    if not _TIMEDELTA_REGEX:
+        _TIMEDELTA_REGEX = re.compile(
+            r"((?P<hours>\d+?)h)?((?P<minutes>\d+?)m)?((?P<seconds>\d+?)s)?"
+        )
+
+    parts = _TIMEDELTA_REGEX.fullmatch(time_str)
     if not parts:
         raise ValueError(f"Unable to parse {time_str}")
     parts = parts.groupdict()
@@ -124,9 +131,18 @@ class Host:
     """
 
     def __init__(self, host_url: str):
+        if not isinstance(host_url, str):
+            raise TypeError("Expected string")
+
         self._url = urlparse(self.format_host(host_url))
         self.hostname = self._url.hostname
         self.port = self._url.port
+
+        if self.hostname is None:
+            raise ValueError("No hostname in host specification")
+
+        if self.port is None:
+            raise ValueError("No port in host specification")
 
     def join_endpoint(self, endpoint: str):
         """Get a URL for the given endpoint."""
@@ -220,16 +236,31 @@ class PersistentState:
 
         # Lock to ensure the state can only be read for states that were
         # successfully committed
+        tempname = None
         try:
             # Try to update and write out the state
             self._state = copy.deepcopy(self._tmp_state)
-            with atomic_write(self._path, overwrite=True) as f:
+            with tempfile.NamedTemporaryFile(
+                mode="w+", delete=False, dir=self._path.parent
+            ) as f:
+                tempname = f.name
                 json.dump(self._state, f, indent=4)
 
-        except Exception as e:
+                # Now overwrite the old file
+                f.close()
+                os.rename(f.name, self._path)
+                tempname = None
+        except (OSError, ValueError, TypeError) as e:
             # If anything happens, rollback to the old state
             self._state = old_state
             raise RuntimeError("Could not commit state.") from e
+        finally:
+            # At the end, delete the temporary file, if it still exists
+            if tempname:
+                try:
+                    os.unlink(tempname)
+                except FileNotFoundError:
+                    pass
 
     def update(self):
         """Return a Context Manager that can atomically update the state.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
   "comet @ git+https://github.com/chime-experiment/comet.git",
   "aiohttp",
   "async_timeout",
-  "atomicwrites",
   "click",
   "deepdiff",
   "jinja2",

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,186 @@
+"""Unit tests for coco.util."""
+
+import json
+import os
+import pathlib
+from datetime import timedelta
+
+import pytest
+
+from coco import util
+
+
+def test_str2timedelta():
+    """Tests for str2timedelta."""
+
+    assert util.str2timedelta("1234") == timedelta(seconds=1234)
+    assert util.str2timedelta("567s") == timedelta(seconds=567)
+    assert util.str2timedelta("9m") == timedelta(seconds=9 * 60)
+    assert util.str2timedelta("1h30m") == timedelta(seconds=90 * 60)
+    assert util.str2timedelta("1h12s") == timedelta(seconds=3612)
+
+    # Things that won't work
+    for bad_time in ["apple", "1.5h", "1s12h"]:
+        with pytest.raises(ValueError):
+            util.str2timedelta(bad_time)
+
+
+def test_str2total_seconds():
+    """Tests for str2total_seconds."""
+
+    assert util.str2total_seconds("1234") == 1234
+    assert util.str2total_seconds("567s") == 567
+    assert util.str2total_seconds("9m") == 9 * 60
+    assert util.str2total_seconds("1h30m") == 90 * 60
+    assert util.str2total_seconds("1h12s") == 3612
+
+    # Things that won't work
+    for bad_time in ["apple", "1.5h", "1s12h"]:
+        with pytest.raises(ValueError):
+            util.str2total_seconds(bad_time)
+
+
+def test_host_init():
+    """Test creating Hosts."""
+
+    assert util.Host("host:1234").url() == "http://host:1234/"
+    assert util.Host("http://host:1234").url() == "http://host:1234/"
+    assert util.Host("http://host:1234/").url() == "http://host:1234/"
+
+    assert str(util.Host("host:1234")) == "host:1234"
+    assert str(util.Host("http://host:1234")) == "host:1234"
+    assert str(util.Host("http://host:1234/")) == "host:1234"
+
+    # These don't work
+    with pytest.raises(ValueError):
+        util.Host("http://host/")
+    with pytest.raises(ValueError):
+        util.Host(":1234")
+    with pytest.raises(TypeError):
+        util.Host(None)
+
+
+def test_host_endpoint():
+    """Test Host.join_endpoint."""
+
+    assert util.Host("host:1234").join_endpoint("end/pt") == "http://host:1234/end/pt"
+    assert (
+        util.Host("http://host:1234").join_endpoint("end/pt")
+        == "http://host:1234/end/pt"
+    )
+    assert (
+        util.Host("http://host:1234/").join_endpoint("end/pt")
+        == "http://host:1234/end/pt"
+    )
+
+
+def test_host_equality():
+    """Test comparing Hosts."""
+
+    assert util.Host("host:1234") == util.Host("host:1234")
+    assert util.Host("http://host:1234") == util.Host("host:1234")
+    assert util.Host("http://host:1234/") == util.Host("host:1234")
+
+
+def test_host_hashing():
+    """Test hashing Hosts."""
+
+    # Hosts with the same hostname and port have the same hash
+    assert {util.Host("host:1234"): "a"}.keys() == {util.Host("host:1234"): "b"}.keys()
+    assert {util.Host("http://host:1234"): "a"}.keys() == {
+        util.Host("host:1234"): "b"
+    }.keys()
+    assert {util.Host("http://host:1234/"): "a"}.keys() == {
+        util.Host("host:1234"): "b"
+    }.keys()
+
+
+def test_ps_read(fs):
+    """Test trying to read persistent state from disk."""
+
+    fs.create_file("/persistent/state.json", contents=json.dumps({"test": "value"}))
+
+    ps = util.PersistentState(pathlib.Path("/persistent/state.json"))
+    assert ps.state == {"test": "value"}
+
+
+def test_ps_noupdate(fs):
+    """Test trying to set persistent state while not in update mode."""
+
+    fs.create_file("/persistent/state.json", contents=json.dumps({"test": "value"}))
+
+    ps = util.PersistentState(pathlib.Path("/persistent/state.json"))
+    assert ps.state == {"test": "value"}
+
+    with pytest.raises(RuntimeError):
+        ps.state = {"new": "state"}
+
+    assert ps.state == {"test": "value"}
+
+
+def test_ps_update(fs):
+    """Test trying to update a persistent state normally."""
+
+    # Need a file to load the persistent state
+    fs.create_file("/persistent/state.json", contents=json.dumps({"test": "value"}))
+
+    ps = util.PersistentState(pathlib.Path("/persistent/state.json"))
+    assert ps.state == {"test": "value"}
+
+    with ps.update():
+        ps.state = {"new": "state"}
+
+    # Update worked.
+    assert ps.state == {"new": "state"}
+
+    # Check the file on disk:
+    with open("/persistent/state.json") as f:
+        diskstate = json.load(f)
+    assert diskstate == ps.state
+
+
+def test_ps_update_failed(fs):
+    """Test rollback after a failed update."""
+
+    fs.create_file("/persistent/state.json", contents=json.dumps({"test": "value"}))
+
+    ps = util.PersistentState(pathlib.Path("/persistent/state.json"))
+    assert ps.state == {"test": "value"}
+
+    # Make the directory read-only
+    os.chmod("/persistent", mode=0o0500)
+
+    # Update fails
+    with pytest.raises(RuntimeError):
+        with ps.update():
+            ps.state = {"new": "state"}
+
+    # State hasn't changed
+    assert ps.state == {"test": "value"}
+
+    # Check the file on disk
+    with open("/persistent/state.json") as f:
+        diskstate = json.load(f)
+    assert diskstate == ps.state
+
+
+def test_hash_dict():
+    """Test hash_dict."""
+
+    # These should have the same hash
+    a = {"a": 1, "b": [{"c": 2, "d": 3}, {"e": 4, "f": 5}], "g": {"h": 6, "i": 7}}
+    b = {"g": {"i": 7, "h": 6}, "b": [{"d": 3, "c": 2}, {"f": 5, "e": 4}], "a": 1}
+
+    assert util.hash_dict(a) == util.hash_dict(b)
+
+    # These are not
+    a = {"a": 1, "b": [{"c": 2, "d": 3}, {"e": 4, "f": 5}], "g": {"h": 6, "i": 7}}
+    b = {"a": 0, "b": [{"c": 2, "d": 3}, {"e": 4, "f": 5}], "g": {"h": 6, "i": 7}}
+
+    assert util.hash_dict(a) != util.hash_dict(b)
+
+    # Nore are these
+    a = {"a": 1, "b": [{"c": 2, "d": 3}, {"e": 4, "f": 5}], "g": {"h": 6, "i": 7}}
+    b = {"j": 1, "b": [{"c": 2, "d": 3}, {"e": 4, "f": 5}], "g": {"h": 6, "i": 7}}
+
+    assert util.hash_dict(a) != util.hash_dict(b)


### PR DESCRIPTION
Specific fixes:
* defer compiling the TIMEDELTA regex until first use.
* catch various input errors to `Host`
* removed dependency on `atomicwrites` (unmaintained since 2022)

Requires #262 