### PR TITLE
refactor(PersistentState): Use empty dict for empty state instead of None

### DIFF
--- a/coco/state.py
+++ b/coco/state.py
@@ -51,17 +51,12 @@ class State:
                 f"on disk: {self._saved_states}"
             )
 
-        # Initialise persistent storage
+        # Initialise persistent storage with content loaded from disk
         self._storage = PersistentState(Path(storage_path, self._name_active_state))
-
-        # Update state with content from persistent state loaded from disk
-        if not self._storage.state:
-            with self._storage.update():
-                self._storage.state = {}
 
         # If the state storage was empty load state from yaml config files
         if self.is_empty():
-            logger.info("Internal state empty. Loading state from file...")
+            logger.info("Internal state empty. Loading default state...")
             self._load_default_state()
 
         logger.setLevel(log_level)

--- a/coco/util.py
+++ b/coco/util.py
@@ -209,7 +209,7 @@ class PersistentState:
             with path.open("r") as fh:
                 self._state = json.load(fh)
         else:
-            self._state = None
+            self._state = {}
 
     @property
     def state(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,13 +64,20 @@ def coco_config(request, fs):
 
 @pytest.fixture
 def default_paths(fs):
-    """Ensure cocod's default paths exist in the fake filesystem."""
+    """Ensure cocod's default paths exist in the fake filesystem.
+
+    Yields a dict containing the paths.
+    """
 
     # Blocklist
-    fs.create_file("/var/lib/coco/blocklist.json")
+    blocklist = "/var/lib/coco/blocklist.json"
+    fs.create_file(blocklist, contents="{}")
 
     # storage_path
-    fs.create_dir("/var/lib/coco/state/")
+    storage_path = "/var/lib/coco/state/"
+    fs.create_dir(storage_path)
+
+    return {"blocklist": blocklist, "storage_path": storage_path}
 
 
 @pytest.fixture

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,12 @@
+"""Tests for coco.state."""
+
+from coco.state import State
+
+
+def test_new_state(default_paths):
+    """Test loading the state ex nihilo."""
+
+    state = State("INFO", default_paths["storage_path"], {}, [])
+
+    # State is empty
+    assert state.is_empty()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -95,6 +95,13 @@ def test_host_hashing():
     }.keys()
 
 
+def test_ps_empty(fs):
+    """Test empty Persistent State."""
+
+    ps = util.PersistentState(pathlib.Path("/missing/state"))
+    assert ps.state == {}
+
+
 def test_ps_read(fs):
     """Test trying to read persistent state from disk."""
 


### PR DESCRIPTION
The `State` (which is the only thing using `PersistentState`) is setting it to the empty dict anyways in this case, so this saves us a step.