### PR TITLE
fix(logging): Only set log level once.

### DIFF
--- a/coco/core.py
+++ b/coco/core.py
@@ -141,7 +141,6 @@ class Core:
                 self.forwarder,
                 self.config["port"],
                 self.config["metrics_port"],
-                self.config["log_level"],
                 self.frontend_timeout,
             ),
         )
@@ -306,7 +305,7 @@ class Core:
         self.log_level = self.config["log_level"]
 
         try:
-            logger.setLevel(self.log_level)
+            logging.getLogger("coco").setLevel(self.log_level)
             # Also set log level for root logger, inherited by all
             logging.getLogger().setLevel(self.log_level)
         except ValueError as e:
@@ -336,7 +335,6 @@ class Core:
 
         # Init state, tries loading from persistent storage
         self.state = State(
-            self.log_level,
             storage_path,
             self.config["load_state"],
             self.config["exclude_from_reset"],

--- a/coco/scheduler.py
+++ b/coco/scheduler.py
@@ -25,7 +25,7 @@ class Scheduler:
     Each endpoint with a 'schedule' config block get a concurrent timer.
     """
 
-    def __init__(self, endpoints, host, port, frontend_timeout, log_level="INFO"):
+    def __init__(self, endpoints, host, port, frontend_timeout):
         """
         Construct scheduler.
 
@@ -43,7 +43,6 @@ class Scheduler:
         self.tasks = []
         self.timers = []
 
-        logger.setLevel(log_level)
         self.host, self.port = host, port
         self.frontend_timeout = frontend_timeout
 

--- a/coco/state.py
+++ b/coco/state.py
@@ -18,7 +18,6 @@ class State:
 
     def __init__(
         self,
-        log_level,
         storage_path: os.PathLike,
         default_state_files: dict[str, str],
         exclude_from_reset: list[str],
@@ -28,8 +27,6 @@ class State:
 
         Parameters
         ----------
-        log_level : str
-            Log level to use inside this class.
         storage_path : os.PathLike
             Path to the persistent state storage.
         default_state_files : dict[str, str]
@@ -58,8 +55,6 @@ class State:
         if self.is_empty():
             logger.info("Internal state empty. Loading default state...")
             self._load_default_state()
-
-        logger.setLevel(log_level)
 
     def write(self, path, value, name=None):
         """

--- a/coco/worker.py
+++ b/coco/worker.py
@@ -54,9 +54,7 @@ async def _open_redis_connection():
         sys.exit(1)
 
 
-def main_loop(
-    endpoints, forwarder, coco_port, metrics_port, log_level, frontend_timeout
-):
+def main_loop(endpoints, forwarder, coco_port, metrics_port, frontend_timeout):
     """
     Wait for tasks and run them.
 
@@ -204,8 +202,6 @@ def main_loop(
         # optionally close connection
         await conn.close()
 
-    logger.setLevel(log_level)
-
     # NOTE: need to create a new event loop here otherwise macOS seems to have
     # issues involving the asyncio event loop and the Process fork
     loop = asyncio.new_event_loop()
@@ -214,9 +210,7 @@ def main_loop(
     # Start up slack logging for the worker
     slack.start(loop)
 
-    scheduler = Scheduler(
-        endpoints, "127.0.0.1", coco_port, frontend_timeout, log_level
-    )
+    scheduler = Scheduler(endpoints, "127.0.0.1", coco_port, frontend_timeout)
     loop.run_until_complete(asyncio.gather(go(), scheduler.start()))
 
     # Cleanup

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -6,7 +6,7 @@ from coco.state import State
 def test_new_state(default_paths):
     """Test loading the state ex nihilo."""
 
-    state = State("INFO", default_paths["storage_path"], {}, [])
+    state = State(default_paths["storage_path"], {}, [])
 
     # State is empty
     assert state.is_empty()


### PR DESCRIPTION
We don't need to set the log level in every single logger. Instead, we only set it on the root "coco" logger and everything should properly cascade.