### PR TITLE
fix(Host): Allow no port in Host specification

### DIFF
--- a/coco/util.py
+++ b/coco/util.py
@@ -141,9 +141,6 @@ class Host:
         if self.hostname is None:
             raise ValueError("No hostname in host specification")
 
-        if self.port is None:
-            raise ValueError("No port in host specification")
-
     def join_endpoint(self, endpoint: str):
         """Get a URL for the given endpoint."""
         return self._url._replace(path=endpoint).geturl()
@@ -159,6 +156,8 @@ class Host:
         return hash((self.hostname, self.port))
 
     def __str__(self):
+        if not self.port:
+            return self.hostname
         return f"{self.hostname}:{self.port}"
 
     def __format__(self, format_spec):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -46,14 +46,14 @@ def test_host_init():
     assert util.Host("host:1234").url() == "http://host:1234/"
     assert util.Host("http://host:1234").url() == "http://host:1234/"
     assert util.Host("http://host:1234/").url() == "http://host:1234/"
+    assert util.Host("http://host/").url() == "http://host/"
 
     assert str(util.Host("host:1234")) == "host:1234"
     assert str(util.Host("http://host:1234")) == "host:1234"
     assert str(util.Host("http://host:1234/")) == "host:1234"
+    assert str(util.Host("http://host/")) == "host"
 
     # These don't work
-    with pytest.raises(ValueError):
-        util.Host("http://host/")
     with pytest.raises(ValueError):
         util.Host(":1234")
     with pytest.raises(TypeError):


### PR DESCRIPTION
Instead, handle no port properly in `Host.__str__`.

This is a partial revert of #266.