### PR TITLE
fix(state): Fix path traversal vulnerability

### DIFF
--- a/coco/state.py
+++ b/coco/state.py
@@ -384,6 +384,13 @@ class State:
                 f"Can't use {self._name_active_state} for saved state. "
                 "This name is reserved. Choose something else."
             )
+
+        # Don't allow writing out of the storage_path
+        if name != Path(name).name:
+            raise InvalidUsage(
+                f"Cannot use '{name}' as a state.  Choose something else."
+            )
+
         overwrite = request.get("overwrite", False)
 
         # only overwrite an existing state if requested explicitly

--- a/coco/util.py
+++ b/coco/util.py
@@ -252,7 +252,7 @@ class PersistentState:
         except (OSError, ValueError, TypeError) as e:
             # If anything happens, rollback to the old state
             self._state = old_state
-            raise RuntimeError("Could not commit state.") from e
+            raise RuntimeError(f"Could not commit state: {e}") from e
         finally:
             # At the end, delete the temporary file, if it still exists
             if tempname:

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,5 +1,12 @@
 """Tests for coco.state."""
 
+import asyncio
+import json
+import pathlib
+
+import pytest
+
+from coco import exceptions
 from coco.state import State
 
 
@@ -10,3 +17,56 @@ def test_new_state(default_paths):
 
     # State is empty
     assert state.is_empty()
+
+
+def test_restore_active(fs, default_paths):
+    """Check restoring the active state."""
+
+    # Current state
+    storage_path = default_paths["storage_path"]
+    fs.create_file(f"{storage_path}/active", contents='{"active": "canary"}')
+
+    # Instantiate the state
+    state = State(default_paths["storage_path"], {}, [])
+
+    # Verify
+    assert state.read("active") == "canary"
+
+
+def test_out_of_tree_state(fs, default_paths):
+    """Check directory scoping.
+
+    cocod shouldn't be reading or writing state files outside of "storage_path".
+    """
+
+    # Current state
+    storage_path = default_paths["storage_path"]
+    fs.create_file(f"{storage_path}/active", contents='{"active": "canary"}')
+
+    # Create an out-of-tree state file
+    elsewhere = pathlib.Path(storage_path, "../elsewhere").resolve()
+    fs.create_dir(elsewhere)
+    fs.create_file("{elsewhere}/state", contents='{"dont": "overwrite"}')
+
+    # Instantiate the state
+    state = State(default_paths["storage_path"], {}, [])
+
+    # Verify
+    assert state.read("active") == "canary"
+
+    # Loading state from elsewhere shouldn't work.
+    with pytest.raises(exceptions.InvalidUsage):
+        asyncio.run(state.load_state({"name": "../elsewhere/state"}))
+
+    # State hasn't changed
+    assert state.read("/active") == "canary"
+    assert not state.exists("dont")
+
+    # Saving state from elesewhere shouldn't work either.
+    with pytest.raises(exceptions.InvalidUsage):
+        asyncio.run(state.save_state({"name": "../elsewhere/state"}))
+
+    # File on disk not changed
+    with open("{elsewhere}/state") as f:
+        diskstate = json.load(f)
+    assert diskstate == {"dont": "overwrite"}


### PR DESCRIPTION
This fixes a path traversal vulnerability in `State.save_state` which was permitting writes to anywhere in the filesystem accessible to `cocod`.

cf: [CWE-23: Relative Path Traversal](https://cwe.mitre.org/data/definitions/23.html)