### PR TITLE
Various fixes for the `State` class

### DIFF
--- a/coco/state.py
+++ b/coco/state.py
@@ -17,38 +17,40 @@ ACTIVE = "active"
 
 
 class State:
-    """Representation of the complete state of all hosts (configs) coco controls."""
+    """This is the complete state of all hosts (configs) coco controls.
+
+    Parameters
+    ----------
+    storage_path : os.PathLike
+        Path to the persistent state storage.
+    default_state_files : dict[str, str]
+        Yaml files that are loaded to build the default state. Keys are state paths.
+    exclude_from_reset : list[str]
+        State paths that should be preserved during reset.
+    """
 
     def __init__(
         self,
         storage_path: os.PathLike,
         default_state_files: dict[str, str],
         exclude_from_reset: list[str],
-    ):
-        """
-        Construct the state.
-
-        Parameters
-        ----------
-        storage_path : os.PathLike
-            Path to the persistent state storage.
-        default_state_files : dict[str, str]
-            Yaml files that are loaded to build the default state. Keys are state paths.
-        exclude_from_reset : list[str]
-            State paths that should be preserved during reset.
-        """
+    ) -> None:
         self.default_state_files = default_state_files
         self.exclude_from_reset = exclude_from_reset
         self._storage_path = storage_path
 
         # List saved states on disk
-        p = Path(self._storage_path).glob("**/*")
-        self._saved_states = [f.name for f in p if f.is_file()]
+        self._saved_states = set()
+        for item in Path(self._storage_path).iterdir():
+            if item.is_file() and item.name != ACTIVE:
+                self._saved_states.add(item.name)
         if self._saved_states:
             logger.info(
-                f"Found {len(self._saved_states)} previously saved states "
-                f"on disk: {self._saved_states}"
+                f"Found {len(self._saved_states)} previously saved states on disk: "
+                + self._saved_states_list
             )
+        else:
+            logger.info("No saved states found.")
 
         # Initialise persistent storage with content loaded from disk
         self._storage = PersistentState(Path(storage_path, ACTIVE))
@@ -337,9 +339,16 @@ class State:
         element = self._find(path)
         return hash_dict(element)
 
+    @property
+    def _saved_states_list(self) -> str:
+        """Print a list of saved states."""
+        if not self._saved_states:
+            return ""
+
+        return " ".join(sorted(self._saved_states))
+
     def is_empty(self):
-        """
-        Tell if the state is empty.
+        """Tell if the state is empty.
 
         Returns
         -------
@@ -352,10 +361,6 @@ class State:
         """Load internal state from yaml files."""
         for path, file in self.default_state_files.items():
             self.read_from_file(path, file)
-
-    def saved_state_exists(self, name: str):
-        """Check if a saved state with a given name exists."""
-        return name in self._saved_states
 
     async def reset_state(self, _: dict | None = None):
         """
@@ -373,8 +378,7 @@ class State:
         self._recover_excluded_paths(excluded)
 
     async def save_state(self, request: dict = {}):
-        """
-        Process the POST request to save (backup) the state.
+        """Process the POST request to save (backup) the state.
 
         The request dictionary should contain an item with key "name" that
         holds a string with the name of the saved state.
@@ -393,17 +397,16 @@ class State:
                 f"Cannot use '{name}' as a state.  Choose something else."
             )
 
-        overwrite = request.get("overwrite", False)
-
         # only overwrite an existing state if requested explicitly
-        if self.saved_state_exists(name):
+        if name in self._saved_states:
+            overwrite = bool(request.get("overwrite", False))
             if not overwrite:
                 raise InvalidUsage(
                     f"Saved state '{name}' already exists. Choose something "
                     "else or try again with 'overwrite=True'."
                 )
-            overwrite = True
         else:
+            # Disable the overwrite flag if we don't need to overwrite
             overwrite = False
 
         # save the active state to <name>
@@ -414,7 +417,7 @@ class State:
         logger.debug(f"Saved state to {Path(self._storage_path, name)}")
         if not overwrite:
             # add saved state to index
-            self._saved_states.append(name)
+            self._saved_states.add(name)
         return Result(
             "save-state",
             result={Host("coco"): (f"Saved state {name}", 200)},
@@ -422,24 +425,17 @@ class State:
         )
 
     async def load_state(self, request: dict = {}):
-        """
-        Process the POST request to load a previously saved state.
+        """Process the POST request to load a previously saved state.
 
         Clear the internal state and re-load a state previously saved. Paths under
         `exclude_from_reset` in the config will not be overwritten by this.
         """
         # get request parameters
         name = request.get("name")
-        if name == ACTIVE:
+        if name not in self._saved_states:
             raise InvalidUsage(
-                f"Can't load state {name}. This name is reserved "
-                "(it's the one that is active now)"
-                f". Choose any other from {self._saved_states}."
-            )
-        if not self.saved_state_exists(name):
-            raise InvalidUsage(
-                f"No saved state with name '{name}' exists. Choose one of "
-                f"{self._saved_states}."
+                f"No saved state with name '{name}'. Choose one of: "
+                + self._saved_states_list
             )
 
         excluded = self._backup_excluded_paths()
@@ -457,14 +453,13 @@ class State:
         )
 
     async def get_saved_states(self, _: dict = {}):
-        """
-        Process the GET request to list all saved states.
+        """Process the GET request to list all saved states.
 
         Returns a list of previously saved states on disk.
         """
         return Result(
             "saved-states",
-            result={Host("coco"): (self._saved_states, 200)},
+            result={Host("coco"): (sorted(self._saved_states), 200)},
             type_="FULL",
         )
 

--- a/coco/state.py
+++ b/coco/state.py
@@ -12,6 +12,9 @@ from .util import Host, PersistentState, hash_dict, yaml_load
 
 logger = logging.getLogger(__name__)
 
+# This is the name of the file (in the "storage_path") containing the active state.
+ACTIVE = "active"
+
 
 class State:
     """Representation of the complete state of all hosts (configs) coco controls."""
@@ -37,7 +40,6 @@ class State:
         self.default_state_files = default_state_files
         self.exclude_from_reset = exclude_from_reset
         self._storage_path = storage_path
-        self._name_active_state = "active"
 
         # List saved states on disk
         p = Path(self._storage_path).glob("**/*")
@@ -49,7 +51,7 @@ class State:
             )
 
         # Initialise persistent storage with content loaded from disk
-        self._storage = PersistentState(Path(storage_path, self._name_active_state))
+        self._storage = PersistentState(Path(storage_path, ACTIVE))
 
         # If the state storage was empty load state from yaml config files
         if self.is_empty():
@@ -379,9 +381,9 @@ class State:
         """
         # get request parameters
         name = request.get("name", "backup")
-        if name == self._name_active_state:
+        if name == ACTIVE:
             raise InvalidUsage(
-                f"Can't use {self._name_active_state} for saved state. "
+                f"Can't use {ACTIVE} for saved state. "
                 "This name is reserved. Choose something else."
             )
 
@@ -428,7 +430,7 @@ class State:
         """
         # get request parameters
         name = request.get("name")
-        if name == self._name_active_state:
+        if name == ACTIVE:
             raise InvalidUsage(
                 f"Can't load state {name}. This name is reserved "
                 "(it's the one that is active now)"

--- a/coco/util.py
+++ b/coco/util.py
@@ -18,6 +18,8 @@ from urllib.parse import urlparse
 import msgpack
 import yaml
 
+from .exceptions import InternalError
+
 _TIMEDELTA_REGEX = None
 
 
@@ -252,7 +254,7 @@ class PersistentState:
         except (OSError, ValueError, TypeError) as e:
             # If anything happens, rollback to the old state
             self._state = old_state
-            raise RuntimeError(f"Could not commit state: {e}") from e
+            raise InternalError(f"Could not commit state: {e}") from e
         finally:
             # At the end, delete the temporary file, if it still exists
             if tempname:

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -6,8 +6,8 @@ import pathlib
 
 import pytest
 
-from coco import exceptions
-from coco.state import State
+from coco import exceptions, util
+from coco.state import ACTIVE, State
 
 
 def test_new_state(default_paths):
@@ -70,3 +70,43 @@ def test_out_of_tree_state(fs, default_paths):
     with open("{elsewhere}/state") as f:
         diskstate = json.load(f)
     assert diskstate == {"dont": "overwrite"}
+
+
+def test_save_states_list(fs, default_paths):
+    """Test listing saved states"""
+
+    storage_path = default_paths["storage_path"]
+
+    # The saved states we have
+    states = {"state1", "state2", "state3", "state4"}
+
+    # Create some (empty) saved states
+    for s in states:
+        fs.create_file(f"{storage_path}/{s}", contents="{}")
+
+    # Also create the active state
+    fs.create_file(f"{storage_path}/{ACTIVE}", contents="{}")
+
+    state = State(default_paths["storage_path"], {}, [])
+
+    # The active state isn't in the set
+    assert ACTIVE not in state._saved_states
+
+    # Check the whole set
+    assert states == state._saved_states
+
+
+def test_get_saved_states(fs, default_paths):
+    """Test the Result from State.get_saved_states."""
+
+    # Create some (empty) saved states
+    storage_path = default_paths["storage_path"]
+    states = {"state1", "state2", "state3", "state4"}
+    for s in states:
+        fs.create_file(f"{storage_path}/{s}")
+
+    state = State(default_paths["storage_path"], {}, [])
+
+    result = asyncio.run(state.get_saved_states())
+
+    assert result.results == {"saved-states": {util.Host("coco"): sorted(states)}}

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -110,3 +110,66 @@ def test_get_saved_states(fs, default_paths):
     result = asyncio.run(state.get_saved_states())
 
     assert result.results == {"saved-states": {util.Host("coco"): sorted(states)}}
+
+
+def test_save_state(fs, default_paths):
+    """Test saving state."""
+
+    # Initial state
+    storage_path = default_paths["storage_path"]
+    fs.create_file(f"{storage_path}/{ACTIVE}", contents='{"key": "value"}')
+
+    state = State(default_paths["storage_path"], {}, [])
+
+    # Save the state
+    result = asyncio.run(state.save_state({"name": "test"}))
+
+    assert result.results == {"save-state": {util.Host("coco"): "Saved state test"}}
+
+    # Check file on disk
+    with open(f"{storage_path}/test") as f:
+        assert json.load(f) == {"key": "value"}
+
+    # The new backup is now in the saved state list
+    result = asyncio.run(state.get_saved_states())
+    assert result.results == {"saved-states": {util.Host("coco"): ["test"]}}
+
+
+def test_save_to_active(fs, default_paths):
+    """Not allowed to save state with the name "active"."""
+
+    # Initial state
+    storage_path = default_paths["storage_path"]
+    fs.create_file(f"{storage_path}/{ACTIVE}", contents='{"key": "value"}')
+
+    state = State(default_paths["storage_path"], {}, [])
+
+    # This shouldn't work.
+    with pytest.raises(exceptions.InvalidUsage):
+        asyncio.run(state.save_state({"name": ACTIVE}))
+
+
+def test_save_to_existing(fs, default_paths):
+    """Attempt to save to an existing state file."""
+
+    # Initial state
+    storage_path = default_paths["storage_path"]
+    fs.create_file(f"{storage_path}/{ACTIVE}", contents='{"key": "value"}')
+
+    # An old state that we want to save to
+    fs.create_file(f"{storage_path}/backup", contents='{"old": "data"}')
+
+    state = State(default_paths["storage_path"], {}, [])
+
+    # This shouldn't work.
+    with pytest.raises(exceptions.InvalidUsage):
+        asyncio.run(state.save_state({"name": "backup"}))
+
+    # But this should
+    result = asyncio.run(state.save_state({"name": "backup", "overwrite": True}))
+
+    assert result.results == {"save-state": {util.Host("coco"): "Saved state backup"}}
+
+    # Check file on disk
+    with open(f"{storage_path}/backup") as f:
+        assert json.load(f) == {"key": "value"}

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import os
 import pathlib
 
 import pytest
@@ -173,3 +174,23 @@ def test_save_to_existing(fs, default_paths):
     # Check file on disk
     with open(f"{storage_path}/backup") as f:
         assert json.load(f) == {"key": "value"}
+
+
+def test_save_state_error(fs, default_paths):
+    """Test error propagation when saving state."""
+
+    # Initial state
+    storage_path = default_paths["storage_path"]
+    fs.create_file(f"{storage_path}/{ACTIVE}", contents='{"key": "value"}')
+
+    # Make the state directory read-only
+    os.chmod(storage_path, mode=0o0500)
+
+    state = State(default_paths["storage_path"], {}, [])
+
+    # This shouldn't work.
+    with pytest.raises(exceptions.InternalError):
+        asyncio.run(state.save_state({"name": "backup"}))
+
+    # Saved state doesn't exist
+    assert not pathlib.Path(storage_path, "test").exists()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 
 import pytest
 
-from coco import util
+from coco import exceptions, util
 
 
 def test_str2timedelta():
@@ -158,7 +158,7 @@ def test_ps_update_failed(fs):
     os.chmod("/persistent", mode=0o0500)
 
     # Update fails
-    with pytest.raises(RuntimeError):
+    with pytest.raises(exceptions.InternalError):
         with ps.update():
             ps.state = {"new": "state"}
 


### PR DESCRIPTION
Specifically:
* Make the name of the active state file a module global (`ACTIVE`) instead of burying it in instance vars
* use `iterdir` instead of `glob` to find state files
* use `set` instead of `list` to hold the states
* exclude the active state from the list of saved states
* sort the saved states returned by get_saved_states
* use `InternalError` for I/O errors writing to state files so that the error propagates back to the client.

Plus some more tests for `State.save_state`, which is mostly working fine as-is.