### PR TITLE
fix(state): Get the load-state endpoint working

### DIFF
--- a/coco/state.py
+++ b/coco/state.py
@@ -52,8 +52,9 @@ class State:
         else:
             logger.info("No saved states found.")
 
-        # Initialise persistent storage with content loaded from disk
-        self._storage = PersistentState(Path(storage_path, ACTIVE))
+        # Initialise persistent storage with content loaded from disk, which
+        # may not exist
+        self._storage = PersistentState(Path(storage_path, ACTIVE), missing_ok=True)
 
         # If the state storage was empty load state from yaml config files
         if self.is_empty():
@@ -410,7 +411,7 @@ class State:
             overwrite = False
 
         # save the active state to <name>
-        saved_state = PersistentState(Path(self._storage_path, name))
+        saved_state = PersistentState(Path(self._storage_path, name), missing_ok=True)
         with saved_state.update():
             saved_state.state = self._storage.state
 
@@ -440,12 +441,11 @@ class State:
 
         excluded = self._backup_excluded_paths()
 
-        # Reset persistent state
-        with self._storage.update():
-            self._storage.state = {}
-        self.read_from_file("", str(Path(self._storage_path, name)))
+        # Overwrite our internal storage with a new PersistentState
+        self._storage = PersistentState(Path(self._storage_path, name))
 
         self._recover_excluded_paths(excluded)
+
         return Result(
             "load-state",
             result={Host("coco"): (f"Loaded state {name}", 200)},

--- a/coco/util.py
+++ b/coco/util.py
@@ -1,15 +1,11 @@
-"""
-Utility functions.
-
-The str2time* functions were stolen from dias
-(https://github.com/chime-experiment/dias/blob/master/dias/utils/string_converter.py).
-"""
+"""Utility functions."""
 
 import collections
 import copy
 import hashlib
 import json
 import os
+import pathlib
 import re
 import tempfile
 from datetime import timedelta
@@ -198,17 +194,28 @@ class PersistentState:
 
     Parameters
     ----------
-    path
+    path : pathlib.Path
         Path to file to serialise the state in.
+    missng_ok : bool, optional
+        If True, set the state to the empty dict if the file at `path` doesn't
+        exist.  Defaults to False.
+
+    Raises
+    ------
+    coco.exceptions.InternalError
+        Loading the state from disk failed.
     """
 
-    def __init__(self, path: os.PathLike):
+    def __init__(self, path: pathlib.Path, missing_ok: bool = False):
         self._path = path
         self._update = False
 
-        if path.exists():
-            with path.open("r") as fh:
-                self._state = json.load(fh)
+        if not missing_ok or path.exists():
+            try:
+                with path.open("r") as fh:
+                    self._state = json.load(fh)
+            except (OSError, json.JSONDecodeError) as e:
+                raise InternalError("Unable to load state: {e}") from e
         else:
             self._state = {}
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -194,3 +194,52 @@ def test_save_state_error(fs, default_paths):
 
     # Saved state doesn't exist
     assert not pathlib.Path(storage_path, "test").exists()
+
+
+def test_state_reload(fs, default_paths):
+    """Attempt to load a saved state."""
+
+    # Current state
+    storage_path = default_paths["storage_path"]
+    fs.create_file(f"{storage_path}/active", contents='{"key": "value"}')
+
+    # State to load
+    fs.create_file(f"{storage_path}/test", contents='{"other": "data"}')
+
+    state = State(default_paths["storage_path"], {}, [])
+
+    # Load the other state
+    result = asyncio.run(state.load_state({"name": "test"}))
+    assert result.results == {"load-state": {util.Host("coco"): "Loaded state test"}}
+
+    # Check that it's now the active state.
+    assert state.read("other") == "data"
+
+
+def test_state_reload_error(fs, default_paths):
+    """Test errors in load-state."""
+
+    # Current state
+    storage_path = default_paths["storage_path"]
+    fs.create_file(f"{storage_path}/active", contents='{"key": "value"}')
+
+    # States to load
+    fs.create_file(f"{storage_path}/invalid", contents="{{{{{")
+    fs.create_file(f"{storage_path}/missing", contents="{}")
+
+    state = State(default_paths["storage_path"], {}, [])
+
+    # Loading invalid state fails
+    with pytest.raises(exceptions.InternalError):
+        asyncio.run(state.load_state({"name": "invalid"}))
+
+    # State hasn't changed
+    assert state.read("key") == "value"
+
+    # Loading missing state fails
+    os.unlink(f"{storage_path}/missing")
+    with pytest.raises(exceptions.InternalError):
+        asyncio.run(state.load_state({"name": "missing"}))
+
+    # State hasn't changed
+    assert state.read("key") == "value"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -98,7 +98,12 @@ def test_host_hashing():
 def test_ps_empty(fs):
     """Test empty Persistent State."""
 
-    ps = util.PersistentState(pathlib.Path("/missing/state"))
+    # By default, this doesn't work
+    with pytest.raises(exceptions.InternalError):
+        util.PersistentState(pathlib.Path("/missing/state"))
+
+    # But this works
+    ps = util.PersistentState(pathlib.Path("/missing/state"), missing_ok=True)
     assert ps.state == {}
 
 
@@ -109,6 +114,21 @@ def test_ps_read(fs):
 
     ps = util.PersistentState(pathlib.Path("/persistent/state.json"))
     assert ps.state == {"test": "value"}
+
+
+def test_ps_read_error(fs):
+    """Test errors reading persistent state from disk."""
+
+    # Invalid Json
+    fs.create_file("/persistent/invalid.json", contents="{{{{{{")
+    with pytest.raises(exceptions.InternalError):
+        util.PersistentState(pathlib.Path("/persistent/invalid.json"))
+
+    # I/O error
+    fs.create_file("/persistent/permission.json", contents="{}")
+    os.chmod("/persistent/permission.json", mode=0)
+    with pytest.raises(exceptions.InternalError):
+        util.PersistentState(pathlib.Path("/persistent/permission.json"))
 
 
 def test_ps_noupdate(fs):


### PR DESCRIPTION
It looks like this endpoint has never worked!  It was trying to load the state from disk as a YAML file (it's JSON).  This re-implements load-state so it now works.

Specifics:
* add optional bool to `PersistentState` to tell it whether the file it's trying to load may be missing.  Missing files are OK when first loading the active state, but not during the `load-state` endpoint.
* Re-implemented `load-state` to mint a new `PersistentState` to read the file, instead of using `State.read_from_file` which is for loading kotekan YAML files.
* Read errors from `PersistentState` are now reported with `InternalError` so they propagate back to the client.