### PR TITLE
fix(state): Permit overwriting invalid state files

### DIFF
--- a/coco/state.py
+++ b/coco/state.py
@@ -411,9 +411,7 @@ class State:
             overwrite = False
 
         # save the active state to <name>
-        saved_state = PersistentState(Path(self._storage_path, name), missing_ok=True)
-        with saved_state.update():
-            saved_state.state = self._storage.state
+        PersistentState(Path(self._storage_path, name), set_to=self._storage.state)
 
         logger.debug(f"Saved state to {Path(self._storage_path, name)}")
         if not overwrite:

--- a/coco/util.py
+++ b/coco/util.py
@@ -196,28 +196,37 @@ class PersistentState:
     ----------
     path : pathlib.Path
         Path to file to serialise the state in.
+    set_to : dict or None, optional
+        If not None, the state is set to this value on creation. In this case,
+        existing data on disk is not loaded, but the state provided by this argument
+        overwrites the state on disk immediately.  Defaults to None.
     missng_ok : bool, optional
         If True, set the state to the empty dict if the file at `path` doesn't
-        exist.  Defaults to False.
+        exist.  Ignrored if `set_to` is not ``None``.  Defaults to False.
 
     Raises
     ------
     coco.exceptions.InternalError
-        Loading the state from disk failed.
+        An I/O error occurred reading or writing the state file on disk.
     """
 
-    def __init__(self, path: pathlib.Path, missing_ok: bool = False):
+    def __init__(
+        self, path: pathlib.Path, set_to: dict | None = None, missing_ok: bool = False
+    ):
         self._path = path
         self._update = False
+        self._state = {}
 
-        if not missing_ok or path.exists():
+        if set_to is not None:
+            # Attempt to update.  Raises InternalError on failure
+            with self.update():
+                self.state = set_to
+        elif not missing_ok or path.exists():
             try:
                 with path.open("r") as fh:
                     self._state = json.load(fh)
             except (OSError, json.JSONDecodeError) as e:
                 raise InternalError("Unable to load state: {e}") from e
-        else:
-            self._state = {}
 
     @property
     def state(self):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -176,6 +176,28 @@ def test_save_to_existing(fs, default_paths):
         assert json.load(f) == {"key": "value"}
 
 
+def test_save_overwrite_invalid(fs, default_paths):
+    """Attempt to save over a currently invalid state."""
+
+    # Initial state
+    storage_path = default_paths["storage_path"]
+    fs.create_file(f"{storage_path}/{ACTIVE}", contents='{"key": "value"}')
+
+    # An old invalid state that we want to overwrite
+    fs.create_file(f"{storage_path}/backup", contents="{{{{{{{")
+
+    state = State(default_paths["storage_path"], {}, [])
+
+    # This should work, even though the state currently can't be read.
+    result = asyncio.run(state.save_state({"name": "backup", "overwrite": True}))
+
+    assert result.results == {"save-state": {util.Host("coco"): "Saved state backup"}}
+
+    # Check file on disk
+    with open(f"{storage_path}/backup") as f:
+        assert json.load(f) == {"key": "value"}
+
+
 def test_save_state_error(fs, default_paths):
     """Test error propagation when saving state."""
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -107,6 +107,25 @@ def test_ps_empty(fs):
     assert ps.state == {}
 
 
+def test_ps_set_to(fs):
+    """Set setting PersistentState on init."""
+
+    # Create existing file
+    fs.create_file("/persistent/state.json", contents=json.dumps({"test": "value"}))
+
+    ps = util.PersistentState(
+        pathlib.Path("/persistent/state.json"), set_to={"new": "state"}
+    )
+
+    # State has been set
+    assert ps.state == {"new": "state"}
+
+    # Check the file on disk:
+    with open("/persistent/state.json") as f:
+        diskstate = json.load(f)
+    assert diskstate == ps.state
+
+
 def test_ps_read(fs):
     """Test trying to read persistent state from disk."""
 


### PR DESCRIPTION
Previously, when running `save-state`, if the target state already existed it would first be read from disk and then immediately overwritten with the active state.

Now, the read-from disk is skipped in this case, meaning writing to states which are currently invalid is possible.   (Before it would result in an unnecessary `InternalError`).