### PR TITLE
feat(core): Add a --full-reset flag to the daemon

### DIFF
--- a/coco/blocklist.py
+++ b/coco/blocklist.py
@@ -26,7 +26,7 @@ class Blocklist:
     def __init__(self, hosts, path: os.PathLike):
         # Initialise persistent storage
         self._state = PersistentState(path)
-        if self._state.state is None:
+        if not self._state.state:
             with self._state.update():
                 self._state.state = {"blocklist_hosts": []}
         self._build_hosts()

--- a/coco/config.py
+++ b/coco/config.py
@@ -135,6 +135,7 @@ _config_skeleton = {
     "frontend_timeout": "10m",
     "exclude_from_reset": [],
     "debug_connections": False,
+    "comet_broker": {"enabled": True},
 }
 
 

--- a/coco/core.py
+++ b/coco/core.py
@@ -53,7 +53,7 @@ class Core:
     Loads and keeps the config and endpoints. Endpoints are called through this module.
     """
 
-    def __init__(self, conf, reset=False, check_config=False):
+    def __init__(self, conf, full_reset=False, reset=False, check_config=False):
         """
         Coco Core.
 
@@ -61,13 +61,18 @@ class Core:
         ----------
         conf : os.PathLike or None
             Path to the config file, if any.
+        full_reset : bool
+            Fully-reset the state, including parts normally excluded from
+            reset.  Default `False`.
         reset : bool
             Whether to reset internal state on start. Default `False`.
         check_config : bool
             Don't really start, check config only. Default `False`.
         """
-        # Tell the destructor that there's no worker to be killed
-        self.check_config = check_config
+
+        # full_reset overrides reset
+        if full_reset:
+            reset = False
 
         # In case constructor crashes before this gets assigned, so that destructor
         # doesn't fail.
@@ -78,16 +83,24 @@ class Core:
         # Load the config
         self._load_config(conf)
 
-        if reset is True:
-            # Reset the internal state
+        # Init state, tries loading from persistent storage, or fully-reset it
+        self.state = State(
+            Path(self.config["storage_path"]),
+            self.config["load_state"],
+            self.config["exclude_from_reset"],
+            reset_on_init=full_reset,
+        )
+
+        # Normal reset
+        if reset:
             asyncio.run(self.state.reset_state())
 
         # Configure the forwarder
         try:
             timeout = str2total_seconds(self.config["timeout"])
-        except Exception as e:
+        except ValueError as e:
             raise click.ClickException(
-                f"Failed parsing value 'timeout' ({self.config['timeout']})."
+                f"Failed parsing value 'timeout' ({self.config['timeout']}): {e}"
             ) from e
         self.forwarder = RequestForwarder(
             self.blocklist_path,
@@ -107,13 +120,13 @@ class Core:
 
         try:
             self.frontend_timeout = str2total_seconds(self.config["frontend_timeout"])
-        except Exception as e:
+        except ValueError as e:
             raise click.ClickException(
                 "Failed parsing value 'frontend_timeout' "
-                f"({self.config['frontend_timeout']})."
+                f"({self.config['frontend_timeout']}): {e}"
             ) from e
 
-        if self.check_config:
+        if check_config:
             logger.info("Superficial config check successful. Stopping...")
             return
 
@@ -161,7 +174,7 @@ class Core:
 
         Join the worker process.
         """
-        if self.redis_sync and not self.check_config:
+        if self.redis_sync:
             logger.info("Joining worker process...")
             try:
                 self.redis_sync.rpush("queue", "coco_shutdown")
@@ -328,23 +341,27 @@ class Core:
                 f'Storage path "{self.config["storage_path"]}" is not a directory.'
             )
 
-        # Read groups
-        self.groups = self.config["groups"].copy()
-        for group, hosts in self.groups.items():
-            self.groups[group] = [Host(h) for h in hosts]
-
-        # Init state, tries loading from persistent storage
-        self.state = State(
-            storage_path,
-            self.config["load_state"],
-            self.config["exclude_from_reset"],
-        )
+        # Parse groups
+        self.groups = {}
+        try:
+            for group, hosts in self.config["groups"].items():
+                if not isinstance(hosts, list):
+                    raise TypeError()
+                self.groups[group] = [Host(h) for h in hosts]
+        except (TypeError, AttributeError) as e:
+            raise click.ClickException(
+                "groups must be a map containing host lists."
+            ) from e
+        except ValueError as e:
+            raise click.ClickException(f"bad hostname in groups: {e}") from e
 
         # Validate slack posting rules
-        # TODO: move into config.py
         for rdict in self.config["slack_rules"]:
-            if "logger" not in rdict or "channel" not in rdict:
-                logger.error(f"Invalid slack rule {rdict}.")
+            for key in ["logger", "channel"]:
+                if key not in rdict:
+                    raise click.ClickException(
+                        f"Required key {key} missing from slack rule: {rdict}."
+                    )
 
     def _load_endpoints(self):
         self.endpoints = {}
@@ -503,9 +520,17 @@ class Core:
     help="Read coco conf file specified by PATH",
 )
 @click.option(
+    "--full-reset",
+    is_flag=True,
+    default=False,
+    help="Fully reset the internal state on start.  Similar to --reset except this "
+    "also resets everything that is normally excluded from reset.  Use this if "
+    "active state on disk is corrupt and coco can't start-up.",
+)
+@click.option(
     "--reset", is_flag=True, default=False, help="Reset the internal state on start"
 )
-def cocod(conf, reset, check_config):
+def cocod(conf, full_reset, reset, check_config):
     """This is the coco (Config Control) server."""
-    Core(conf=conf, reset=reset, check_config=check_config)
+    Core(conf=conf, full_reset=full_reset, reset=reset, check_config=check_config)
     return 0

--- a/coco/state.py
+++ b/coco/state.py
@@ -27,6 +27,10 @@ class State:
         Yaml files that are loaded to build the default state. Keys are state paths.
     exclude_from_reset : list[str]
         State paths that should be preserved during reset.
+    reset_on_init : bool
+        If True, the state is reset on init, instead of being restored from the active
+        state on disk.  This is different than calling reset_state(), since this ignores
+        "exclude_from_reset".
     """
 
     def __init__(
@@ -34,6 +38,7 @@ class State:
         storage_path: os.PathLike,
         default_state_files: dict[str, str],
         exclude_from_reset: list[str],
+        reset_on_init: bool,
     ) -> None:
         self.default_state_files = default_state_files
         self.exclude_from_reset = exclude_from_reset
@@ -52,11 +57,16 @@ class State:
         else:
             logger.info("No saved states found.")
 
-        # Initialise persistent storage with content loaded from disk, which
-        # may not exist
-        self._storage = PersistentState(Path(storage_path, ACTIVE), missing_ok=True)
+        if reset_on_init:
+            # Manually set an empty state, instead of reading from disk
+            self._storage = PersistentState(Path(storage_path, ACTIVE), set_to={})
+        else:
+            # Initialise persistent storage with content loaded from disk, which
+            # may not exist
+            self._storage = PersistentState(Path(storage_path, ACTIVE), missing_ok=True)
 
-        # If the state storage was empty load state from yaml config files
+        # If the state storage was empty (maybe due to reset_on_init), load state
+        # from yaml config files
         if self.is_empty():
             logger.info("Internal state empty. Loading default state...")
             self._load_default_state()

--- a/coco/util.py
+++ b/coco/util.py
@@ -137,7 +137,7 @@ class Host:
         self.port = self._url.port
 
         if self.hostname is None:
-            raise ValueError("No hostname in host specification")
+            raise ValueError(f"No hostname in host specification ({host_url})")
 
     def join_endpoint(self, endpoint: str):
         """Get a URL for the given endpoint."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,7 @@ def coco_config(request, fs):
         _config = {
             "host": "cocohost",
             "endpoint_dir": "/etc/coco/endpoints",
-            "groups": ["defgroup"],
+            "groups": {"defgroup": ["host:1234"]},
         }
 
     # Merge in any test-specific config

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -89,7 +89,7 @@ def test_default_config(coco_config):
         {
             "host": "cocohost",
             "endpoint_dir": "/etc/coco/endpoints",
-            "groups": ["defgroup"],
+            "groups": {"defgroup": ["host:1234"]},
             "endpoints": [{"group": "defgroup", "name": "endpoint"}],
         },
     )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -52,3 +52,67 @@ def test_storage_path_not_dir(fs, cocod):
     fs.create_file("/storage/path", contents="")
     result = cocod(1)
     assert "/storage/path" in result.output
+
+
+@pytest.mark.coco_config({"groups": ["group1", "group2"]})
+def test_groups_not_map(fs, cocod):
+    """The "groups" config must be a dict of lists."""
+
+    result = cocod(1)
+    assert "groups" in result.output
+
+
+@pytest.mark.coco_config({"groups": {"group1": "scalar"}})
+def test_groups_not_list(fs, cocod):
+    """The "groups" config must ce a dict of lists."""
+
+    result = cocod(1)
+    assert "groups" in result.output
+
+
+@pytest.mark.coco_config({"groups": {"group1": [":1234"]}})
+def test_groups_bad_host(fs, cocod):
+    """Test catching bad hosts in groups lists."""
+
+    result = cocod(1)
+    assert ":1234" in result.output
+
+
+@pytest.mark.coco_config({"slack_rules": [{"logger": "logger"}]})
+def test_slack_rules_no_channel(fs, cocod):
+    """Slack rules must contain a "channel" key."""
+
+    result = cocod(1)
+    assert "channel" in result.output
+
+
+@pytest.mark.coco_config({"slack_rules": [{"channel": "channel"}]})
+def test_slack_rules_no_logger(fs, cocod):
+    """Slack rules must contain a "logger" key."""
+
+    result = cocod(1)
+    assert "logger" in result.output
+
+
+@pytest.mark.coco_config({"comet_broker": {"enabled": False}})
+def test_reset(fs, default_paths, cocod):
+    """Check --reset works."""
+
+    # Current state
+    storage_path = default_paths["storage_path"]
+    fs.create_file(f"{storage_path}/active", contents='{"key": "value"}')
+
+    # --check-config ensures the daemon exits after the test.
+    cocod(0, ["--reset", "--check-config"])
+
+
+@pytest.mark.coco_config({"comet_broker": {"enabled": False}})
+def test_full_reset(fs, default_paths, cocod):
+    """Check --full-reset works."""
+
+    # Current state file can be invalid in this case
+    storage_path = default_paths["storage_path"]
+    fs.create_file(f"{storage_path}/active", contents="{{{{{{")
+
+    # --check-config ensures the daemon exits after the test.
+    cocod(0, ["--full-reset", "--check-config"])

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -14,7 +14,7 @@ from coco.state import ACTIVE, State
 def test_new_state(default_paths):
     """Test loading the state ex nihilo."""
 
-    state = State(default_paths["storage_path"], {}, [])
+    state = State(default_paths["storage_path"], {}, [], False)
 
     # State is empty
     assert state.is_empty()
@@ -28,7 +28,7 @@ def test_restore_active(fs, default_paths):
     fs.create_file(f"{storage_path}/active", contents='{"active": "canary"}')
 
     # Instantiate the state
-    state = State(default_paths["storage_path"], {}, [])
+    state = State(default_paths["storage_path"], {}, [], False)
 
     # Verify
     assert state.read("active") == "canary"
@@ -50,7 +50,7 @@ def test_out_of_tree_state(fs, default_paths):
     fs.create_file("{elsewhere}/state", contents='{"dont": "overwrite"}')
 
     # Instantiate the state
-    state = State(default_paths["storage_path"], {}, [])
+    state = State(default_paths["storage_path"], {}, [], False)
 
     # Verify
     assert state.read("active") == "canary"
@@ -88,7 +88,7 @@ def test_save_states_list(fs, default_paths):
     # Also create the active state
     fs.create_file(f"{storage_path}/{ACTIVE}", contents="{}")
 
-    state = State(default_paths["storage_path"], {}, [])
+    state = State(default_paths["storage_path"], {}, [], False)
 
     # The active state isn't in the set
     assert ACTIVE not in state._saved_states
@@ -106,7 +106,7 @@ def test_get_saved_states(fs, default_paths):
     for s in states:
         fs.create_file(f"{storage_path}/{s}")
 
-    state = State(default_paths["storage_path"], {}, [])
+    state = State(default_paths["storage_path"], {}, [], False)
 
     result = asyncio.run(state.get_saved_states())
 
@@ -120,7 +120,7 @@ def test_save_state(fs, default_paths):
     storage_path = default_paths["storage_path"]
     fs.create_file(f"{storage_path}/{ACTIVE}", contents='{"key": "value"}')
 
-    state = State(default_paths["storage_path"], {}, [])
+    state = State(default_paths["storage_path"], {}, [], False)
 
     # Save the state
     result = asyncio.run(state.save_state({"name": "test"}))
@@ -143,7 +143,7 @@ def test_save_to_active(fs, default_paths):
     storage_path = default_paths["storage_path"]
     fs.create_file(f"{storage_path}/{ACTIVE}", contents='{"key": "value"}')
 
-    state = State(default_paths["storage_path"], {}, [])
+    state = State(default_paths["storage_path"], {}, [], False)
 
     # This shouldn't work.
     with pytest.raises(exceptions.InvalidUsage):
@@ -160,7 +160,7 @@ def test_save_to_existing(fs, default_paths):
     # An old state that we want to save to
     fs.create_file(f"{storage_path}/backup", contents='{"old": "data"}')
 
-    state = State(default_paths["storage_path"], {}, [])
+    state = State(default_paths["storage_path"], {}, [], False)
 
     # This shouldn't work.
     with pytest.raises(exceptions.InvalidUsage):
@@ -186,7 +186,7 @@ def test_save_overwrite_invalid(fs, default_paths):
     # An old invalid state that we want to overwrite
     fs.create_file(f"{storage_path}/backup", contents="{{{{{{{")
 
-    state = State(default_paths["storage_path"], {}, [])
+    state = State(default_paths["storage_path"], {}, [], False)
 
     # This should work, even though the state currently can't be read.
     result = asyncio.run(state.save_state({"name": "backup", "overwrite": True}))
@@ -208,7 +208,7 @@ def test_save_state_error(fs, default_paths):
     # Make the state directory read-only
     os.chmod(storage_path, mode=0o0500)
 
-    state = State(default_paths["storage_path"], {}, [])
+    state = State(default_paths["storage_path"], {}, [], False)
 
     # This shouldn't work.
     with pytest.raises(exceptions.InternalError):
@@ -228,7 +228,7 @@ def test_state_reload(fs, default_paths):
     # State to load
     fs.create_file(f"{storage_path}/test", contents='{"other": "data"}')
 
-    state = State(default_paths["storage_path"], {}, [])
+    state = State(default_paths["storage_path"], {}, [], False)
 
     # Load the other state
     result = asyncio.run(state.load_state({"name": "test"}))
@@ -249,7 +249,7 @@ def test_state_reload_error(fs, default_paths):
     fs.create_file(f"{storage_path}/invalid", contents="{{{{{")
     fs.create_file(f"{storage_path}/missing", contents="{}")
 
-    state = State(default_paths["storage_path"], {}, [])
+    state = State(default_paths["storage_path"], {}, [], False)
 
     # Loading invalid state fails
     with pytest.raises(exceptions.InternalError):
@@ -265,3 +265,51 @@ def test_state_reload_error(fs, default_paths):
 
     # State hasn't changed
     assert state.read("key") == "value"
+
+
+def test_reset_state(fs, default_paths):
+    """Check resetting the state."""
+
+    # Current state
+    storage_path = default_paths["storage_path"]
+    fs.create_file(
+        f"{storage_path}/active", contents='{"keep": "keep", "discard": "discard"}'
+    )
+
+    # Default state file
+    fs.create_file("/coco/default.yaml", contents="key: value")
+
+    # Instantiate the state.  "keep" is in the exclude_from_reset list.
+    state = State(
+        default_paths["storage_path"], {"loaded": "/coco/default.yaml"}, ["keep"], False
+    )
+
+    # Verify state was restored
+    assert state.read("keep") == "keep"
+    assert state.read("discard") == "discard"
+
+    # Reset state
+    asyncio.run(state.reset_state())
+
+    # "keep" has been kept, but "discard" is discarded
+    assert state.read("keep") == "keep"
+    assert not state.exists("discard")
+
+    # Conf has been loaded from disk
+    assert state.read("loaded/key") == "value"
+
+
+def test_reset_on_init(fs, default_paths):
+    """Check reset-on-init / full-reset."""
+
+    # Current state
+    storage_path = default_paths["storage_path"]
+    fs.create_file(
+        f"{storage_path}/active", contents='{"keep": "keep", "discard": "discard"}'
+    )
+
+    # Instantiate the state.  "keep" is in the exclude_from_reset list.
+    state = State(default_paths["storage_path"], {}, ["keep"], True)
+
+    # State is empty (exclude_from_reset was ignored).
+    assert state.is_empty()


### PR DESCRIPTION
This fully resets the state (ignoring `exclude_from_reset`).  For use when everything has gone pear-shaped.

Other fixes/updates for state creation/resetting:
* Moved `State` creation out of `_check_config` (state is not config).
* No need to store `check_config` in the instance: the `redis_sync`
  attribute is sufficient for the destructor.
* Improve vetting of the "groups" config.
* Fix the default "groups" config in the test suite.
* Improve error messages for "slack_rules" checks.
* Report the invalid `host_url` when failing to create a `Host`.

Test suite is now up to the instantiation of the RequestForwarder / endpoint loading.

Also:
* Set "comet_broker/enabled" to True in the default config.  The "comet_broker" section is not optional in the config.
* Properly handle empty/missing blocklists.  This is a fix for a regression introduced by me in #267