### PR TITLE
fix(slack): Don't report 429 errors

### DIFF
--- a/coco/slack.py
+++ b/coco/slack.py
@@ -156,7 +156,9 @@ class SlackMessageQueue(LogMessageQueue):
                 async with session.post(
                     url, json=entry, headers=headers, timeout=self.timeout
                 ) as response:
-                    if response.status != 200:
+                    # Don't report "Too Many Requests"/429 messages.  There's nothing
+                    # we can do about that (other than send less frequently.)
+                    if response.status != 200 and response.status != 429:
                         print(
                             f"Sending message to slack server failed with status:"
                             f" {response.reason} ({response.status}).\n"


### PR DESCRIPTION
HTTP 429 errors are a result of coco sending too many messages in a short period of time.  We know coco does this.  There's nothing to do in this case and all these messages are doing is filling up the journal.