### PR TITLE
fix(core): Remove deprecated comet call

### DIFF
--- a/coco/core.py
+++ b/coco/core.py
@@ -300,9 +300,13 @@ class Core:
                     f"'comet_broker/{exc}' not defined in config."
                 ) from exc
             comet = Manager(comet_host, comet_port)
+
             try:
-                comet.register_start(datetime.datetime.utcnow(), __version__)
-                comet.register_config(self.config)
+                comet.register_start(
+                    datetime.datetime.now(datetime.timezone.utc),
+                    __version__,
+                    self.config,
+                )
             except CometError as exc:
                 raise InternalError(
                     f"Comet failed registering CoCo startup and initial config: {exc}"

--- a/coco/core.py
+++ b/coco/core.py
@@ -186,9 +186,8 @@ class Core:
             self._kill_worker()
 
     def _kill_worker(self):
-        if hasattr(self, "qworker"):
-            if self.qworker:
-                self.qworker.kill()
+        if self.qworker:
+            self.qworker.kill()
 
     def _call_endpoints_on_start(self):
         for endpoint in self.endpoints.values():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Common test fixtures"""
 
+import json
 import traceback
 
 import pytest
@@ -7,26 +8,37 @@ import yaml
 
 from coco import config
 
+pytest_plugins = ["rest_server"]
+
+# Default test config used in the coco_config fixture
+DEFAULT_TEST_CONFIG = {
+    "host": "cocohost",
+    "endpoint_dir": "/etc/coco/endpoints",
+    "groups": {"defgroup": ["host:1234"]},
+    "comet_broker": {"enabled": False},
+}
+
 
 def pytest_configure(config):
     """This function extends the pytest config file."""
 
     config.addinivalue_line(
         "markers",
-        "no_default_config(*flag): "
+        "no_default_config(flag): "
         "If flag is True, the default test config is not used.",
-    )
-    config.addinivalue_line(
-        "markers",
-        "coco_config(*config_dict): "
-        "used to set the coco.config for testing.  config_dict"
-        "is merged with the default config.",
     )
 
 
 @pytest.fixture
 def coco_config(request, fs):
-    """Fixture creating the config file for CLI tests."""
+    """Fixture creating the config file for CLI tests.
+
+    Yields a function which can be called to add more config to the
+    coco config file at runtime:
+
+    def test_something(coco_config):
+        coco_config({"more": "config"})
+    """
 
     # Check whether to skip the default config
     marker = request.node.get_closest_marker("no_default_config")
@@ -38,28 +50,82 @@ def coco_config(request, fs):
     if no_default_config:
         _config = {}
     else:
-        _config = {
-            "host": "cocohost",
-            "endpoint_dir": "/etc/coco/endpoints",
-            "groups": {"defgroup": ["host:1234"]},
+        _config = DEFAULT_TEST_CONFIG
+
+    # Create the directory for the coco config file.
+    fs.create_dir("/etc/coco")
+
+    def _write_config(extra_config={}):
+        """Helper function to add extra config to the coco config file."""
+        nonlocal _config
+
+        # Append to existing config
+        if extra_config:
+            if not isinstance(extra_config, dict):
+                raise RuntimeError("non-dict passed to coco_config().")
+            _config = config.merge_dict_tree(_config, extra_config)
+
+        # If there's no config, create nothing.
+        if _config:
+            # Dump it to a file
+            with open("/etc/coco/coco.conf", "w") as f:
+                yaml.dump(_config, f)
+
+    # Write the config, if any
+    _write_config()
+
+    # Create a default endpoint, so something's there.
+    fs.create_file(
+        "/etc/coco/endpoints/endpoint.conf", contents=yaml.dump({"group": "defgroup"})
+    )
+
+    # Yield the function so test can update the config
+    return _write_config
+
+
+@pytest.fixture
+def mock_comet(coco_config, rest_server):
+    """Provides a mock comet broker.
+
+    Configuration for this comet is added to the coco config.
+
+    Provides the RestTest instance to the tests.
+    """
+
+    def _register_state(route, body):
+        """Pretend to be comet's /register-state endpoint."""
+
+        # Decode body
+        body = json.loads(body)
+
+        return {"result": "success", "request": "get_state", "hash": body["hash"]}
+
+    # Create a mock broker
+    comet_broker = rest_server()
+
+    # Add comet endpoints
+    comet_broker.add_route("/register-state", method="POST", callback=_register_state)
+    comet_broker.add_route("/send-state", method="POST", response={"result": "success"})
+
+    # Start the mock
+    comet_broker.start()
+
+    # Configure coco for mock-comet
+    coco_config(
+        {
+            "comet_broker": {
+                "enabled": True,
+                "host": "127.0.0.1",
+                "port": comet_broker.port,
+            }
         }
+    )
 
-    # Merge in any test-specific config
-    marker = request.node.get_closest_marker("coco_config")
-    if marker is not None:
-        _config = config.merge_dict_tree(_config, marker.args[0])
+    # Yield the comet broker mock.
+    yield comet_broker
 
-    # If there's no config, create nothing.
-    if _config:
-        # Dump it to a file
-        fs.create_file("/etc/coco/coco.conf", contents=yaml.dump(_config))
-
-        if not no_default_config:
-            # Create a default endpoint, so something's there.
-            fs.create_file(
-                "/etc/coco/endpoints/endpoint.conf",
-                contents=yaml.dump({"group": "defgroup"}),
-            )
+    # Ensure server is shut down
+    comet_broker.shutdown()
 
 
 @pytest.fixture

--- a/tests/rest_server.py
+++ b/tests/rest_server.py
@@ -1,0 +1,320 @@
+"""A generic REST server used for testing."""
+
+import http.server
+import json
+import threading
+from collections import namedtuple
+from http import HTTPStatus
+
+import pytest
+
+__all__ = ["rest_server"]
+
+# Stores route information
+Route = namedtuple("Route", ["path", "method", "callback", "response"])
+
+# Stores hit information
+Hit = namedtuple("Hit", ["path", "method", "request", "code", "response"])
+
+
+@pytest.fixture
+def rest_server():
+    return RestServer
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    """Handles requests from the server.
+
+    A new instance of this class is created on every connection.
+    """
+
+    def record_hit(self, code, body, response=None):
+        """Record a hit on the rest server."""
+
+        # The hit is recorded under the base path
+        path = self.path.split("?", 1)[0]
+        path = path.split("#", 1)[0]
+
+        # Pass back up to the RestServer instance
+        self.server.rest_server.record_hit(
+            path, Hit(self.path, self.command, body, int(code), response)
+        )
+
+    def send_json(self, body, response):
+        """JSON-encode "response" and send it back."""
+
+        # Send an empty response if not given one
+        if response is None:
+            self.record_hit(HTTPStatus.NO_CONTENT, body)
+            self.send_error(HTTPStatus.NO_CONTENT, body)
+            return
+
+        # Record
+        self.record_hit(HTTPStatus.OK, body, response)
+
+        # JSON encode
+        response = json.dumps(response)
+
+        # Respond with success (=200)
+        self.send_response_only(HTTPStatus.OK)
+
+        # Headers
+        self.send_header("Server", self.version_string())
+        self.send_header("Date", self.date_time_string())
+        self.send_header("Connection", "close")
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(response)))
+        self.end_headers()
+
+        # Response goes in the body
+        self.wfile.write(response.encode())
+        return
+
+    def handle_route(self):
+        """Handle a request."""
+
+        # Set to True if a path matches but the method is wrong
+        bad_method = False
+
+        # Split the path itself from the query
+        query_split = self.path.split("?", 1)
+        path = query_split[0]
+        if len(query_split) > 1:
+            body = "?" + query_split[1]
+
+        # Split the path from the fragment
+        fragment_split = path.split("#", 1)
+        path = fragment_split[0]
+        if len(fragment_split) > 1:
+            if body:
+                body += "#" + fragment_split[1]
+            else:
+                body = "#" + fragment_split[1]
+
+        # Read the body from a POST
+        if self.command == "POST":
+            body = self.rfile.read(int(self.headers["Content-Length"]))
+
+        # Find a route for this request
+        for route in self.server.rest_server.routes:
+            if route.path == path:
+                if route.method == self.command:
+                    # Handle the route
+                    if route.callback:
+                        response = route.callback(route, body.decode())
+                    else:
+                        response = route.response
+                    # Return the response.
+                    self.send_json(body, response)
+                    return
+                bad_method = True
+
+        # No matching route.  Send an error
+        error_code = (
+            HTTPStatus.METHOD_NOT_ALLOWED if bad_method else HTTPStatus.NOT_FOUND
+        )
+        self.record_hit(error_code, body)
+        self.send_error(error_code)
+        return
+
+    # The BaseHTTPRequestHandler separate handling by HTTP command.
+    # But we don't need that.
+    do_GET = handle_route
+    do_POST = handle_route
+
+
+class RestServer:
+    """A generic REST server used for testing.
+
+    Server instances listen on random ephemeral port on 127.0.0.1 meaning
+    multiple servers can be used simultaneously, and the server won't get in the
+    way of or be blocked by other (real) servers running on the test platform.
+
+    How to use:
+    1.  Add routes to the server by calling `add_route`.
+    2.  Start the server with `start`.
+    3.  Use the "port" attribute to get this port number from the running server.
+    4.  Call `shutdown` when finished with the server to ensure it exits cleanly.
+    """
+
+    def __init__(self):
+        self.server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+        self.port = self.server.server_port
+
+        # So the Handler can find this instance
+        self.server.rest_server = self
+
+        # List of routes added with add_route
+        self.routes = []
+
+        # Dict of routes hit, keyed by path.
+        self._hits = {}
+
+        # Server runs in this thread
+        self.thread = None
+
+        # Is the server running?
+        self.running = False
+
+    def add_route(self, path, method="GET", callback=None, response=None):
+        """Add a route to the server.
+
+        If neither `callback` nor `response` is given, an empty response
+        (HTTP status = 204) will be sent back to the client.
+
+        Parameters
+        ----------
+        path : str
+            The route (URL) path
+        method : str, optional
+            The method for the route.  Defaults to "GET"
+        callback : Callable, optional
+            A callback to service the route.  The value returned is JSON
+            encoded and sent back to the client.
+        response : Any, optional
+            A response returned to the client, if callback isn't given.
+        """
+        self.routes.append(
+            Route(path=path, method=method, callback=callback, response=response)
+        )
+
+    def record_hit(self, route, hit):
+        """Record a hit on a route."""
+
+        if route not in self._hits:
+            self._hits[route] = [hit]
+        else:
+            self._hits[route].append(hit)
+
+    def start(self):
+        """Start running the server.
+
+        Raises RuntimeError if no routes have been added or if the server is
+        already running.
+        """
+        if not self.routes:
+            raise RuntimeError("No routes for server")
+        if self.running:
+            raise RuntimeError("Already running")
+
+        self.running = True
+
+        # Create a thread for the server
+        self.thread = threading.Thread(
+            target=self.server.serve_forever, daemon=True, kwargs={"poll_interval": 0.1}
+        )
+
+        # Start it
+        self.thread.start()
+
+    def shutdown(self):
+        """Stop a running server.
+
+        If the server isn't running, this does nothing.
+        """
+        if not self.running:
+            return
+
+        if self.thread:
+            self.server.shutdown()
+            self.thread.join()
+            self.thread = None
+
+        self.running = False
+
+    # Methods for testing interaction with the server
+    def hits(self, route):
+        """A list of hits recorded a route.
+
+        If no hits were made, returns an empty list.
+        """
+        return self._hits.get(route, [])
+
+    def hit_count(self, route):
+        """Number of times "route" was hit.
+
+        Equivalent to `len(hits(route))`
+        """
+        return len(self.hits(route))
+
+    def assert_hit_received(self, route, sent, full=False):
+        """Assert that at least one hit of "route" received "sent".
+
+        Parameters
+        ----------
+        sent : dict
+            The expected data that was sent
+        full : bool
+            If Ture, extra keys may not appear in the received data.
+            Defaults to False, meaning a partial match is okay.
+        """
+
+        def _compare(a, b, equal, path=""):
+            """Check a and b.
+
+            Parameters
+            ----------
+            a, b: Any
+                Items to compare
+            equal:
+                If False, ignore extra keys in "a".
+            path:
+                The path to this element.
+            """
+            display_path = f"in {path}" if path else "at top-level"
+            # Fail if element types differ
+            if type(a) is not type(b):
+                return f"{display_path}: types differ"
+
+            if isinstance(b, dict):
+                a_keys = set(a.keys())
+                b_keys = set(b.keys())
+
+                if equal and (a_keys ^ b_keys):
+                    # Equality requested, but keys are not the same fails
+                    return f"{display_path}: extra keys: {a_keys ^ b_keys}"
+                if not equal and not (a_keys >= b_keys):
+                    # Not equal, but b is not a subset of a
+                    return f"{display_path}: missing keys: {b_keys - a_keys}"
+
+                # If the simple checks passed, loop over keys in b
+                for key in b_keys:
+                    subpath = f'{display_path} -> "{key}"' if path else f'"{key}"'
+                    # Fail if any key values fail
+                    result = _compare(a[key], b[key], equal, subpath)
+                    if result:
+                        return result
+            elif isinstance(b, list):
+                # Fail if lists aren't the same length
+                if len(a) != len(b):
+                    return f"{display_path}: Bad length ({len(a)} != {len(b)})"
+
+                # Zip the lists together and compare
+                for index, items in enumerate(zip(a, b)):
+                    subpath = f"{display_path} -> [{index}]" if path else f"[{index}]"
+                    result = _compare(*items, equal, subpath)
+                    if result:
+                        return result
+            else:
+                # Fail if scalars aren't the same
+                if a != b:
+                    return f"{display_path}: {a} != {b}"
+
+            # Nothing failed
+            return None
+
+        for hit in self.hits(route):
+            # decode the request
+            received = json.loads(hit.request.decode())
+
+            # Return on first success
+            result = _compare(received, sent, full)
+            if not result:
+                return
+
+        # If no matches were made, fail
+        pytest.fail(
+            f'Data not received by route "{route}": {result}\n'
+            f"Expected\n  {sent}\nReceived:\n   "
+            "\n   ".join([str(hit.request.decode()) for hit in self.hits(route)])
+        )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,9 +15,13 @@ def test_no_config(coco_config):
 
 
 @pytest.mark.no_default_config(True)
-@pytest.mark.coco_config({"test": "test"})
 def test_missing_required(coco_config):
     """Test reporting missing required config."""
+
+    # Because of the "no_default_config" mark above, the only config
+    # that we have will be this.  (We need to write something to
+    # the config file for the test fixutre to create it.)
+    coco_config({"test": "test"})
 
     with pytest.raises(click.ClickException) as exinfo:
         config.load_config()
@@ -83,15 +87,16 @@ def test_default_config(coco_config):
     """Loading the default test config should work."""
     result = config.load_config()
 
+    from conftest import DEFAULT_TEST_CONFIG
+
     # Result should be the test default merged with coco's default
     expected_result = config.merge_dict_tree(
-        config._config_skeleton,
-        {
-            "host": "cocohost",
-            "endpoint_dir": "/etc/coco/endpoints",
-            "groups": {"defgroup": ["host:1234"]},
-            "endpoints": [{"group": "defgroup", "name": "endpoint"}],
-        },
+        config._config_skeleton, DEFAULT_TEST_CONFIG
+    )
+
+    # But also the default endpoint
+    expected_result = config.merge_dict_tree(
+        expected_result, {"endpoints": [{"group": "defgroup", "name": "endpoint"}]}
     )
 
     assert result == expected_result
@@ -181,11 +186,11 @@ def test_no_map_endpoing(fs, coco_config):
         config.load_config()
 
 
-@pytest.mark.coco_config(
-    {1234: "test", "subdict": {5.6: "test"}, "dictlist": [{True: "test"}]}
-)
 def test_str_keys(coco_config):
     """All config keys are strings."""
+
+    # Update config
+    coco_config({1234: "test", "subdict": {5.6: "test"}, "dictlist": [{True: "test"}]})
 
     result = config.load_config()
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,7 +1,5 @@
 """Test the coco daemon (coco.core)."""
 
-import pytest
-
 import coco.core
 
 
@@ -12,41 +10,46 @@ def test_help(cocod):
     assert coco.core.cocod.__doc__ in result.output
 
 
-@pytest.mark.coco_config({"log_level": "INVALID"})
-def test_bad_log_level(cocod):
+def test_bad_log_level(cocod, coco_config):
     """Try invalid log_level."""
+
+    coco_config({"log_level": "INVALID"})
 
     result = cocod(1)
     assert "INVALID" in result.output
 
 
-@pytest.mark.coco_config({"blocklist_path": "invalid_blocklist_path"})
-def test_relative_blocklist_path(cocod):
+def test_relative_blocklist_path(cocod, coco_config):
     """blocklist_path must be absolute"""
+
+    coco_config({"blocklist_path": "invalid_blocklist_path"})
 
     result = cocod(1)
     assert "invalid_blocklist_path" in result.output
 
 
-@pytest.mark.coco_config({"storage_path": "invalid_storage_path"})
-def test_relative_storage_path(cocod):
+def test_relative_storage_path(cocod, coco_config):
     """storage_path must be absolute"""
+
+    coco_config({"storage_path": "invalid_storage_path"})
 
     result = cocod(1)
     assert "invalid_storage_path" in result.output
 
 
-@pytest.mark.coco_config({"storage_path": "/storage/path"})
-def test_storage_missing(fs, cocod):
+def test_storage_missing(fs, cocod, coco_config):
     """storage_path must exist"""
+
+    coco_config({"storage_path": "/storage/path"})
 
     result = cocod(1)
     assert "/storage/path" in result.output
 
 
-@pytest.mark.coco_config({"storage_path": "/storage/path"})
-def test_storage_path_not_dir(fs, cocod):
+def test_storage_path_not_dir(fs, cocod, coco_config):
     """storage_path must be a directory"""
+
+    coco_config({"storage_path": "/storage/path"})
 
     # Create a file at the storage_path
     fs.create_file("/storage/path", contents="")
@@ -54,47 +57,51 @@ def test_storage_path_not_dir(fs, cocod):
     assert "/storage/path" in result.output
 
 
-@pytest.mark.coco_config({"groups": ["group1", "group2"]})
-def test_groups_not_map(fs, cocod):
+def test_groups_not_map(fs, cocod, coco_config):
     """The "groups" config must be a dict of lists."""
 
+    coco_config({"groups": ["group1", "group2"]})
+
     result = cocod(1)
     assert "groups" in result.output
 
 
-@pytest.mark.coco_config({"groups": {"group1": "scalar"}})
-def test_groups_not_list(fs, cocod):
+def test_groups_not_list(fs, cocod, coco_config):
     """The "groups" config must ce a dict of lists."""
 
+    coco_config({"groups": {"group1": "scalar"}})
+
     result = cocod(1)
     assert "groups" in result.output
 
 
-@pytest.mark.coco_config({"groups": {"group1": [":1234"]}})
-def test_groups_bad_host(fs, cocod):
+def test_groups_bad_host(fs, cocod, coco_config):
     """Test catching bad hosts in groups lists."""
+
+    coco_config({"groups": {"group1": [":1234"]}})
 
     result = cocod(1)
     assert ":1234" in result.output
 
 
-@pytest.mark.coco_config({"slack_rules": [{"logger": "logger"}]})
-def test_slack_rules_no_channel(fs, cocod):
+def test_slack_rules_no_channel(fs, cocod, coco_config):
     """Slack rules must contain a "channel" key."""
+
+    coco_config({"slack_rules": [{"logger": "logger"}]})
 
     result = cocod(1)
     assert "channel" in result.output
 
 
-@pytest.mark.coco_config({"slack_rules": [{"channel": "channel"}]})
-def test_slack_rules_no_logger(fs, cocod):
+def test_slack_rules_no_logger(fs, cocod, coco_config):
     """Slack rules must contain a "logger" key."""
+
+    coco_config({"slack_rules": [{"channel": "channel"}]})
 
     result = cocod(1)
     assert "logger" in result.output
 
 
-@pytest.mark.coco_config({"comet_broker": {"enabled": False}})
 def test_reset(fs, default_paths, cocod):
     """Check --reset works."""
 
@@ -106,7 +113,6 @@ def test_reset(fs, default_paths, cocod):
     cocod(0, ["--reset", "--check-config"])
 
 
-@pytest.mark.coco_config({"comet_broker": {"enabled": False}})
 def test_full_reset(fs, default_paths, cocod):
     """Check --full-reset works."""
 
@@ -116,3 +122,27 @@ def test_full_reset(fs, default_paths, cocod):
 
     # --check-config ensures the daemon exits after the test.
     cocod(0, ["--full-reset", "--check-config"])
+
+
+def test_comet(fs, mock_comet, cocod):
+    # --check-config ensures the daemon exits after the test.
+    cocod(0, ["--check-config"])
+
+    # Check that everything was registered.  The counts are 2 here
+    # because the "start" state is separate from the "config" state.
+    assert mock_comet.hit_count("/register-state") == 2
+    assert mock_comet.hit_count("/send-state") == 2
+
+    # Check the coco config was sent
+    with open("/etc/coco/coco.conf") as f:
+        # Read it from the fake filesystem.
+        from coco.util import yaml_load
+
+        config = yaml_load(f)
+
+    # Check broker mock
+    from coco import __version__
+
+    mock_comet.assert_hit_received(
+        "/send-state", {"state": {"version": __version__, "config_state": config}}
+    )


### PR DESCRIPTION
The `register_config` function in the comet manager has been deprecated since 2019 when its functionality was merged into `register_start`.

Also:
* removed one unnecessary `hasattr` call in `Core._kill_worker`
* remove deprecated `datetime.utcnow` call.
* by default, disable comet integration in the test-suite
* created a simple REST server to run tests against, rather than having to run the entire comet broker.
* removed the `coco_config` pytest mark and instead provide a function to tests to update the config as needed.

The point in the program flow where the comet interaction is happening in `cocod` is still a problem, but fixing that's going to involve some more test-suite infrastructure that I want to put off to another PR.

To prevent future merging trouble, this is stacked on top of #275 but doesn't really depend on that.