### PR TITLE
feat(config): Allow changing redis port

### DIFF
--- a/coco/config.py
+++ b/coco/config.py
@@ -28,6 +28,9 @@ Example config:
     # Port for prometheus metrics
     metrics_port: 12056
 
+    # Port the redis server is listening on.
+    redis_port: 6379
+
     # Number of workers that will process and forward requests
     n_workers: 2
 
@@ -120,6 +123,7 @@ _config_skeleton = {
     "host": RequiredValue,
     "port": 12055,
     "metrics_port": 9090,
+    "redis_port": 6379,
     "log_level": "INFO",
     "endpoint_dir": RequiredValue,
     "n_workers": 1,

--- a/coco/core.py
+++ b/coco/core.py
@@ -131,7 +131,7 @@ class Core:
             return
 
         # Remove any leftover shutdown commands from the queue
-        self.redis_sync = redis.Redis()
+        self.redis_sync = redis.Redis(port=int(self.config["redis_port"]))
         self.redis_sync.lrem("queue", 0, "coco_shutdown")
 
         # Load queue update script into redis cache
@@ -225,7 +225,10 @@ class Core:
         # ends up in the same event loop
         async def init_redis_async(*_):
             self.redis_async = aioredis.Redis(
-                host="localhost", port=6379, encoding="utf-8", decode_responses=True
+                host="localhost",
+                port=int(self.config["redis_port"]),
+                encoding="utf-8",
+                decode_responses=True,
             )
             await self.redis_async.ping()
 


### PR DESCRIPTION
This adds to the config an optional "redis_port" which can be used to set the redis port (on localhost) that cocod will connect to.  If this value isn't given, it uses the default port 6379, meaning existing deployments work as before.

This is needed by the rewritten coco_runner test fixture that I'm rebuilding in another branch.  This change can't be tested without that fixture, so no test changes here.