### PR TITLE
fix(core): Don't register with comet if --check-config is used

### DIFF
--- a/coco/core.py
+++ b/coco/core.py
@@ -124,7 +124,6 @@ class Core:
         self._load_endpoints()
         self._local_endpoints()
         self._check_endpoint_links()
-        self._register_config()
 
         try:
             self.frontend_timeout = str2total_seconds(self.config["frontend_timeout"])
@@ -137,6 +136,8 @@ class Core:
         if check_config:
             logger.info("Superficial config check successful. Stopping...")
             return
+
+        self._register_config()
 
         # Remove any leftover shutdown commands from the queue
         self.redis_sync = redis.Redis(port=int(self.config["redis_port"]))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,13 +84,8 @@ def coco_config(request, fs):
 
 
 @pytest.fixture
-def mock_comet(coco_config, rest_server):
-    """Provides a mock comet broker.
-
-    Configuration for this comet is added to the coco config.
-
-    Provides the RestTest instance to the tests.
-    """
+def mock_comet(rest_server):
+    """Yields a mocked comet broker."""
 
     def _register_state(route, body):
         """Pretend to be comet's /register-state endpoint."""
@@ -109,17 +104,6 @@ def mock_comet(coco_config, rest_server):
 
     # Start the mock
     comet_broker.start()
-
-    # Configure coco for mock-comet
-    coco_config(
-        {
-            "comet_broker": {
-                "enabled": True,
-                "host": "127.0.0.1",
-                "port": comet_broker.port,
-            }
-        }
-    )
 
     # Yield the comet broker mock.
     yield comet_broker

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -122,9 +122,19 @@ def test_full_reset(fs, storage_path, cocod):
     cocod(0, ["--full-reset", "--check-config"])
 
 
-def test_comet(fs, mock_comet, cocod):
-    # --check-config ensures the daemon exits after the test.
-    cocod(0, ["--check-config"])
+def test_comet(mock_comet, coco_runner):
+    """Ensure coco registers start-up with comet."""
+
+    from coco import __version__
+
+    # Configure comet in the coco_runner
+    runner = coco_runner()
+    runner.add_config(
+        comet_broker={"enabled": True, "host": "127.0.0.1", "port": mock_comet.port}
+    )
+
+    # Start the daemon
+    runner.start_daemon()
 
     # Check that everything was registered.  The counts are 2 here
     # because the "start" state is separate from the "config" state.
@@ -132,15 +142,35 @@ def test_comet(fs, mock_comet, cocod):
     assert mock_comet.hit_count("/send-state") == 2
 
     # Check the coco config was sent
-    with open("/etc/coco/coco.conf") as f:
-        # Read it from the fake filesystem.
-        from coco.util import yaml_load
-
-        config = yaml_load(f)
-
-    # Check broker mock
-    from coco import __version__
-
     mock_comet.assert_hit_received(
-        "/send-state", {"state": {"version": __version__, "config_state": config}}
+        "/send-state",
+        {"state": {"version": __version__, "config_state": runner.config}},
     )
+
+    # Check for no error from daemon
+    runner.stop()
+
+
+def test_comet_check_config(mock_comet, coco_runner):
+    """Test that "cocod --check-config" doesn't invoke comet.
+
+    We don't want cocod registering its start in this case.
+    """
+
+    # Set up daemon to be invoked with --check-config
+    runner = coco_runner(daemon_args=("--check-config",))
+
+    # Configure comet in the coco_runner
+    runner.add_config(
+        comet_broker={"enabled": True, "host": "127.0.0.1", "port": mock_comet.port}
+    )
+
+    # Start the daemon
+    runner.start_daemon()
+
+    # Check that comet wasn't called.
+    assert mock_comet.hit_count("/register-state") == 0
+    assert mock_comet.hit_count("/send-state") == 0
+
+    # Check for no error from daemon
+    runner.stop()


### PR DESCRIPTION
The comet registration via the manager is now deferred until after the early exit caused by --check-config.

This fixes a problem where using --check-config would result in `cocod` spuriously registering its start with comet, even though it was only doing a test run-through of the config.

The prior comet test has been migrated from the `cocod` fixture to the `coco_runner` and the `mock_comet` fixture no longer automatically integrates with the `cocod` fixture.

This is the problem I alluded to in #277

Requires #282.