### PR TITLE
fix(worker): Also abstract the redis port in the worker

### DIFF
--- a/coco/core.py
+++ b/coco/core.py
@@ -162,6 +162,7 @@ class Core:
                 self.forwarder,
                 self.config["port"],
                 self.config["metrics_port"],
+                int(self.config["redis_port"]),
                 self.frontend_timeout,
             ),
         )

--- a/coco/request_forwarder.py
+++ b/coco/request_forwarder.py
@@ -250,7 +250,7 @@ class RequestForwarder:
         """
         self._endpoints[name] = endpoint
 
-    def start_prometheus_server(self, port):
+    def start_prometheus_server(self, port, redis_port):
         """
         Start prometheus server.
 
@@ -258,9 +258,11 @@ class RequestForwarder:
         ----------
         port : int
             Server port.
+        redis_port : int
+            The port redis is listening on
         """
         # Connect to redis
-        self.redis_conn = redis.Redis(host="127.0.0.1", port=6379, db=0)
+        self.redis_conn = redis.Redis(host="127.0.0.1", port=redis_port, db=0)
 
         def fetch_request_count():
             for edpt in self._endpoints:

--- a/coco/worker.py
+++ b/coco/worker.py
@@ -42,10 +42,10 @@ def signal_handler(*_):
 signal.signal(signal.SIGINT, signal_handler)
 
 
-async def _open_redis_connection():
+async def _open_redis_connection(redis_port):
     try:
         return aioredis.from_url(
-            "redis://127.0.0.1:6379", encoding="utf-8", decode_responses=True
+            f"redis://127.0.0.1:{redis_port}", encoding="utf-8", decode_responses=True
         ).client()
     except ConnectionError as e:
         logger.error(
@@ -54,7 +54,9 @@ async def _open_redis_connection():
         sys.exit(1)
 
 
-def main_loop(endpoints, forwarder, coco_port, metrics_port, frontend_timeout):
+def main_loop(
+    endpoints, forwarder, coco_port, metrics_port, redis_port, frontend_timeout
+):
     """
     Wait for tasks and run them.
 
@@ -65,16 +67,24 @@ def main_loop(endpoints, forwarder, coco_port, metrics_port, frontend_timeout):
     endpoints : dict
         A dict with keys being endpoint names and values being of type
         :class:`Endpoint`.
+    forwarder
+        The RequestForwarder
+    coco_port:
+        The coco Sanic port
+    metrics_port:
+        The prometheus metrics port
+    redis_port:
+        The redis server port
     frontend_timeout : int
         Number of seconds before coco sanic frontend times out.
     """
 
     async def go():
         # start the prometheus server for forwarded requests
-        forwarder.start_prometheus_server(metrics_port)
+        forwarder.start_prometheus_server(metrics_port, redis_port)
         forwarder.init_metrics()
 
-        conn = await _open_redis_connection()
+        conn = await _open_redis_connection(redis_port)
         code = None
 
         while True:
@@ -192,7 +202,7 @@ def main_loop(endpoints, forwarder, coco_port, metrics_port, frontend_timeout):
                     )
 
                     # open new connection and try one more time
-                    conn = await _open_redis_connection()
+                    conn = await _open_redis_connection(redis_port)
                     await conn.execute_command(
                         "rpush", f"{name}:res", json.dumps(result)
                     )


### PR DESCRIPTION
(And, in the prom server thread, too, in the request_forwarder).

Missed in #280.  Can't be tested without the coco_runner in #282