### PR TITLE
fix(endpoint): Set report_latency to False in LocalEndpoint

### DIFF
--- a/coco/endpoint.py
+++ b/coco/endpoint.py
@@ -717,6 +717,7 @@ class LocalEndpoint:
         self.name = name
         self.type = type_
         self.callable = callable
+        self.report_latency = False
         self.schedule = None
 
     async def call(self, request, **_):


### PR DESCRIPTION
Prevents an `AttributeError` here when calling a `LocalEndpoint`:

https://github.com/chime-experiment/coco/blob/be2c1ff3d4621b57db4abbf04c9a75ce88179540/coco/worker.py#L155

This seems to have been introduced in #246.  I'm not sure what the outrigger version of coco is doing to prevent this happening.