### PR TITLE
perf(core): Don't use a LocalEndpoint to send the config

### DIFF
--- a/coco/client.py
+++ b/coco/client.py
@@ -418,7 +418,7 @@ class CliGroup(click.Group):
         # Get the coco config from the daemon
         try:
             conn = http.client.HTTPConnection(host, port, timeout=2)
-            conn.request("GET", "/get-coco-config", headers={"Host": host})
+            conn.request("GET", "/config", headers={"Host": host})
             res = conn.getresponse()
         except TimeoutError as e:
             raise click.ClickException(
@@ -445,11 +445,9 @@ class CliGroup(click.Group):
 
         # Decode
         try:
-            data = json.loads(data)
+            coco_config = json.loads(data)
         except json.JSONDecodeError as e:
             raise click.ClickError(f"Failure parsing config from server: {e}") from e
-
-        coco_config = data["coco-config"]["http://coco/"]["reply"]
 
         # Record it
         ctx.obj["coco_config"] = coco_config
@@ -1068,7 +1066,7 @@ def get_config(ctx):
                     + ctx.obj["coco_config"]["host"]
                     + ":"
                     + str(ctx.obj["coco_config"]["port"])
-                    + "/get-coco-config"
+                    + "/config"
                 ),
                 "method": "GET",
             }

--- a/coco/core.py
+++ b/coco/core.py
@@ -32,7 +32,6 @@ from .request_forwarder import (
     CocoForward,
     RequestForwarder,
 )
-from .result import Result
 from .state import State
 from .util import Host, PersistentState, str2total_seconds
 
@@ -284,6 +283,8 @@ class Core:
         self.sanic_app.register_listener(start_slack_log, "before_server_start")
         self.sanic_app.register_listener(stop_slack_log, "after_server_stop")
 
+        self.sanic_app.add_route(self._get_config, "/config", methods=["GET"])
+
         self.sanic_app.add_route(
             self.external_endpoint, "/<endpoint>", methods=["GET", "POST"]
         )
@@ -450,7 +451,6 @@ class Core:
             "reset-state": ("POST", self.state.reset_state),
             "save-state": ("POST", self.state.save_state),
             "load-state": ("POST", self.state.load_state),
-            "get-coco-config": ("GET", self._get_config),
             "wait": ("POST", wait.process_post),
         }
 
@@ -459,11 +459,11 @@ class Core:
             self.forwarder.add_endpoint(name, self.endpoints[name])
 
     async def _get_config(self, _):
-        return Result(
-            "coco-config",
-            result={Host("coco"): (self.config, 200)},
-            type_="FULL",
-        )
+        """Sanic handler for the /config route.
+
+        Returns the coco config.
+        """
+        return response.json(self.config)
 
     def _check_endpoint_links(self):
         def check(e):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -111,7 +111,7 @@ def test_show_call(coco_runner):
         coco_runner.client("--show-call-only", "--json", "config", "get").output
     )
     assert result == {
-        "endpoint": f"http://127.0.0.1:{coco_runner.port}/get-coco-config",
+        "endpoint": f"http://127.0.0.1:{coco_runner.port}/config",
         "method": "GET",
     }
 


### PR DESCRIPTION
This fixes an unintended side-effect of implementing "/get-coco-config" as a cocod `LocalEndpoint`.

Like "real" endpoints, when there's a hit on this cocod `LocalEndpoint`:
* the "get-coco-config" request is appended to the request queue in redis by Sanic
* (eventually) the request is popped off the `queue` by the qworker
* the qworker responds by writing the coco config as the response back to redis
* Once it appears, the Sanic worker pulls the response out of redis and sends it back to the client.

The unintended problem here is serializing the config request with all other coco requests.  Because the client calls this endpoint whenever it starts up, the net effect is: the client is forced to wait for _everything_ already existing in the queue to be handled before it can finish intialising.  If the `cocod` queue happens to be super deep, the client might time-out before Sanic responds with the config.

However, it's not necessary to involve the queue or the qworker at all here, because the coco config is fully sanitized before Sanic starts up.  The Sanic process has the same config as the qworker process.

So, this PR replaces the old "get-coco-config" `LocalEndpoint` with a simple `/config` Sanic route which responds immediately with the coco config (as a standard JSON response, without the coco `Result` framework.)

This should significantly speed-up client start-up in cases where the queue is congested.