### PR TITLE
build: make cocod dependencies optional

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -54,7 +54,7 @@ jobs:
           python-version: ${{ matrix.python_version }}
 
       - name: Install pip dependencies
-        run: pip install .[test]
+        run: pip install .[cocod,test]
 
 #      - name: Start Redis
 #        uses: supercharge/redis-github-action@1.8.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     apt-get install -y apt-utils git build-essential curl \
     libmariadb-dev libevent-dev && \
     pip install --use-deprecated=legacy-resolver flask && \
-    pip install --use-deprecated=legacy-resolver /coco
+    pip install --use-deprecated=legacy-resolver /coco[cocod]
 
 #-----------------------
 # Minimize container size

--- a/coco/util.py
+++ b/coco/util.py
@@ -11,7 +11,6 @@ import tempfile
 from datetime import timedelta
 from urllib.parse import urlparse
 
-import msgpack
 import yaml
 
 from .exceptions import InternalError
@@ -328,6 +327,8 @@ def hash_dict(dict_: dict):
     -------
     Hash
     """
+    import msgpack
+
     serialized = msgpack.packb(sort_dict(dict_), use_bin_type=True)
     _md5 = hashlib.md5()
     _md5.update(serialized)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,21 +18,21 @@ dynamic = ["readme", "version"]
 license = "GPL-3.0-or-later"
 license-files = [ "LICENSE" ]
 dependencies = [
-  "comet @ git+https://github.com/chime-experiment/comet.git",
   "aiohttp",
-  "async_timeout",
   "click>=8.2",
-  "deepdiff",
-  "jinja2",
-  "mmh3",
-  "msgpack",
-  "prometheus_client<0.8",
   "pyyaml",
-  "redis>=4.2.0",
-  "sanic>=20.6.0"
 ]
 
 [project.optional-dependencies]
+cocod = [
+  "comet @ git+https://github.com/chime-experiment/comet.git",
+  "deepdiff",
+  "jinja2",
+  "msgpack",
+  "prometheus_client<0.8",
+  "redis>=4.2.0",
+  "sanic>=20.6.0"
+]
 test = [
   "fakeredis[lua]",
   "pyfakefs >= 5.4",


### PR DESCRIPTION
Only client dependencies are installed by default.

Also removed the no-longer-needed `mmh3` and `async_timeout`.